### PR TITLE
fix: db 테이블 생성 시 quoted 로 인해 json 속성에서 충돌나는 버그 수정

### DIFF
--- a/admin/src/main/resources/application.yml
+++ b/admin/src/main/resources/application.yml
@@ -14,4 +14,4 @@ spring:
     open-in-view: false
     properties.hibernate:
       default_batch_fetch_size: 1000
-      globally_quoted_identifiers: true
+      globally_quoted_identifiers: false

--- a/auth/src/main/resources/application.yml
+++ b/auth/src/main/resources/application.yml
@@ -19,7 +19,7 @@ spring:
     open-in-view: false
     properties.hibernate:
       default_batch_fetch_size: 1000
-      globally_quoted_identifiers: true
+      globally_quoted_identifiers: false
 
 jwt:
   secret: ${JWT_SECRET}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
<!-- ex) #이슈번호[, #이슈번호] -->

> #24 


## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 설명해 주세요. (이미지 첨부 가능) -->

> globally_quoted_identifiers: false 로 변경


## 👀 리뷰어 가이드라인
<!-- 리뷰어가 중점적으로 확인해야 할 사항을 작성해 주세요. -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

> JSON 필드 생성시 quoted 로 생성이 되지 않는 이슈 입니다.
