### PR TITLE
feat: 차량 관제 API 개발

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,5 +37,5 @@ out/
 .vscode/
 
 ### .env ###
-.env.ts
+.env
 .env.*

--- a/.gitignore
+++ b/.gitignore
@@ -37,5 +37,5 @@ out/
 .vscode/
 
 ### .env ###
-.env
+.env.ts
 .env.*

--- a/admin/src/main/java/kernel360/ckt/admin/application/CustomerService.java
+++ b/admin/src/main/java/kernel360/ckt/admin/application/CustomerService.java
@@ -4,7 +4,7 @@ import jakarta.persistence.EntityNotFoundException;
 import kernel360.ckt.admin.application.command.CreateCustomerCommand;
 import kernel360.ckt.admin.ui.dto.request.CustomerUpdateRequest;
 import kernel360.ckt.core.domain.entity.CustomerEntity;
-import kernel360.ckt.core.domain.entity.CustomerStatus;
+import kernel360.ckt.core.domain.enums.CustomerStatus;
 import kernel360.ckt.core.repository.CustomerRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;

--- a/admin/src/main/java/kernel360/ckt/admin/application/VehicleControlTowerService.java
+++ b/admin/src/main/java/kernel360/ckt/admin/application/VehicleControlTowerService.java
@@ -1,0 +1,35 @@
+package kernel360.ckt.admin.application;
+
+import kernel360.ckt.admin.ui.dto.response.VehicleControlTowerResponse;
+import kernel360.ckt.admin.ui.dto.response.VehicleResponse;
+import kernel360.ckt.core.domain.entity.VehicleEntity;
+import kernel360.ckt.core.domain.enums.VehicleControlTowerStatus;
+import kernel360.ckt.core.repository.VehicleControlTowerRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class VehicleControlTowerService {
+
+    private final VehicleControlTowerRepository vehicleControlTowerRepository;
+
+    public VehicleControlTowerResponse getVehicleControlTowerStatusCount() {
+        long totalCount = vehicleControlTowerRepository.countAll();
+        long runningCount = vehicleControlTowerRepository.countByStatus(VehicleControlTowerStatus.RUNNING);
+        long stoppedCount = vehicleControlTowerRepository.countByStatus(VehicleControlTowerStatus.STOPPED);
+        long untrackedCount = vehicleControlTowerRepository.countByStatus(VehicleControlTowerStatus.UNTRACKED);
+
+        return new VehicleControlTowerResponse(totalCount, runningCount, stoppedCount, untrackedCount);
+    }
+
+    public List<VehicleResponse> getRunningVehicles() {
+        List<VehicleEntity> runningVehicles = vehicleControlTowerRepository.findByControlTowerStatus(VehicleControlTowerStatus.RUNNING);
+        return runningVehicles.stream()
+            .map(VehicleResponse::from)
+            .toList();
+    }
+
+}

--- a/admin/src/main/java/kernel360/ckt/admin/infra/repository/jpa/VehicleControlTowerJpaRepository.java
+++ b/admin/src/main/java/kernel360/ckt/admin/infra/repository/jpa/VehicleControlTowerJpaRepository.java
@@ -1,0 +1,9 @@
+package kernel360.ckt.admin.infra.repository.jpa;
+
+import kernel360.ckt.core.domain.entity.VehicleEntity;
+import kernel360.ckt.core.repository.VehicleControlTowerRepository;
+import org.springframework.data.repository.Repository;
+
+public interface VehicleControlTowerJpaRepository extends Repository<VehicleEntity, Long>, VehicleControlTowerRepository {
+
+}

--- a/admin/src/main/java/kernel360/ckt/admin/ui/CustomerController.java
+++ b/admin/src/main/java/kernel360/ckt/admin/ui/CustomerController.java
@@ -9,7 +9,7 @@ import kernel360.ckt.admin.ui.dto.response.CustomerListResponse;
 import kernel360.ckt.admin.ui.dto.response.CustomerResponse;
 import kernel360.ckt.core.common.response.CommonResponse;
 import kernel360.ckt.core.domain.entity.CustomerEntity;
-import kernel360.ckt.core.domain.entity.CustomerStatus;
+import kernel360.ckt.core.domain.enums.CustomerStatus;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;

--- a/admin/src/main/java/kernel360/ckt/admin/ui/VehicleControlTowerController.java
+++ b/admin/src/main/java/kernel360/ckt/admin/ui/VehicleControlTowerController.java
@@ -1,0 +1,33 @@
+package kernel360.ckt.admin.ui;
+
+import kernel360.ckt.admin.application.VehicleControlTowerService;
+import kernel360.ckt.admin.ui.dto.response.VehicleControlTowerResponse;
+import kernel360.ckt.admin.ui.dto.response.VehicleResponse;
+import kernel360.ckt.core.common.response.CommonResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/tracking")
+public class VehicleControlTowerController {
+
+    private final VehicleControlTowerService vehicleControlTowerService;
+
+    @GetMapping("/status")
+    public CommonResponse<VehicleControlTowerResponse> getVehicleStatusCount() {
+        VehicleControlTowerResponse response = vehicleControlTowerService.getVehicleControlTowerStatusCount();
+        return CommonResponse.success(response);
+    }
+
+    @GetMapping("/vehicles/running")
+    public CommonResponse<List<VehicleResponse>> getRunningVehicles() {
+        List<VehicleResponse> response = vehicleControlTowerService.getRunningVehicles();
+        return CommonResponse.success(response);
+    }
+
+}

--- a/admin/src/main/java/kernel360/ckt/admin/ui/dto/response/VehicleControlTowerResponse.java
+++ b/admin/src/main/java/kernel360/ckt/admin/ui/dto/response/VehicleControlTowerResponse.java
@@ -1,0 +1,9 @@
+package kernel360.ckt.admin.ui.dto.response;
+
+public record VehicleControlTowerResponse (
+    long totalCount,
+    long runningCount, // 운행중
+    long stoppedCount, // 미운행
+    long untrackedCount // 미관제
+
+) {}

--- a/core/src/main/java/kernel360/ckt/core/domain/entity/CustomerEntity.java
+++ b/core/src/main/java/kernel360/ckt/core/domain/entity/CustomerEntity.java
@@ -1,6 +1,7 @@
 package kernel360.ckt.core.domain.entity;
 
 import jakarta.persistence.*;
+import kernel360.ckt.core.domain.enums.CustomerStatus;
 import lombok.*;
 
 @Getter

--- a/core/src/main/java/kernel360/ckt/core/domain/entity/VehicleEntity.java
+++ b/core/src/main/java/kernel360/ckt/core/domain/entity/VehicleEntity.java
@@ -1,6 +1,7 @@
 package kernel360.ckt.core.domain.entity;
 
 import jakarta.persistence.*;
+import kernel360.ckt.core.domain.enums.VehicleControlTowerStatus;
 import kernel360.ckt.core.domain.enums.VehicleStatus;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -41,6 +42,10 @@ public class VehicleEntity {
     @Enumerated(EnumType.STRING)
     @Column
     private VehicleStatus status;
+
+    @Enumerated(EnumType.STRING)
+    @Column
+    private VehicleControlTowerStatus ControlTowerstatus;
 
     @Lob
     private String memo;

--- a/core/src/main/java/kernel360/ckt/core/domain/entity/VehicleEntity.java
+++ b/core/src/main/java/kernel360/ckt/core/domain/entity/VehicleEntity.java
@@ -45,7 +45,7 @@ public class VehicleEntity {
 
     @Enumerated(EnumType.STRING)
     @Column
-    private VehicleControlTowerStatus ControlTowerstatus;
+    private VehicleControlTowerStatus controlTowerstatus;
 
     @Lob
     private String memo;

--- a/core/src/main/java/kernel360/ckt/core/domain/enums/CustomerStatus.java
+++ b/core/src/main/java/kernel360/ckt/core/domain/enums/CustomerStatus.java
@@ -1,4 +1,4 @@
-package kernel360.ckt.core.domain.entity;
+package kernel360.ckt.core.domain.enums;
 
 import lombok.Getter;
 

--- a/core/src/main/java/kernel360/ckt/core/domain/enums/VehicleControlTowerStatus.java
+++ b/core/src/main/java/kernel360/ckt/core/domain/enums/VehicleControlTowerStatus.java
@@ -1,7 +1,13 @@
 package kernel360.ckt.core.domain.enums;
 
 public enum VehicleControlTowerStatus {
-    RUNNING,
-    STOPPED,
-    UNTRACKED
+    RUNNING("운행중"),
+    STOPPED("미운행"),
+    UNTRACKED("미관제");
+
+    private final String description;
+
+    VehicleControlTowerStatus(String description) {
+        this.description = description;
+    }
 }

--- a/core/src/main/java/kernel360/ckt/core/domain/enums/VehicleControlTowerStatus.java
+++ b/core/src/main/java/kernel360/ckt/core/domain/enums/VehicleControlTowerStatus.java
@@ -1,0 +1,7 @@
+package kernel360.ckt.core.domain.enums;
+
+public enum VehicleControlTowerStatus {
+    RUNNING,
+    STOPPED,
+    UNTRACKED
+}

--- a/core/src/main/java/kernel360/ckt/core/repository/CustomerRepository.java
+++ b/core/src/main/java/kernel360/ckt/core/repository/CustomerRepository.java
@@ -1,7 +1,7 @@
 package kernel360.ckt.core.repository;
 
 import kernel360.ckt.core.domain.entity.CustomerEntity;
-import kernel360.ckt.core.domain.entity.CustomerStatus;
+import kernel360.ckt.core.domain.enums.CustomerStatus;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.Query;

--- a/core/src/main/java/kernel360/ckt/core/repository/VehicleControlTowerRepository.java
+++ b/core/src/main/java/kernel360/ckt/core/repository/VehicleControlTowerRepository.java
@@ -12,10 +12,10 @@ public interface VehicleControlTowerRepository {
     @Query("SELECT COUNT(v) FROM VehicleEntity v")
     long countAll();
 
-    @Query("SELECT COUNT(v) FROM VehicleEntity v WHERE v.ControlTowerstatus = :status")
+    @Query("SELECT COUNT(v) FROM VehicleEntity v WHERE v.controlTowerstatus = :status")
     long countByStatus(@Param("status") VehicleControlTowerStatus status);
 
-    @Query("SELECT v FROM VehicleEntity v WHERE v.ControlTowerstatus = :status")
+    @Query("SELECT v FROM VehicleEntity v WHERE v.controlTowerstatus = :status")
     List<VehicleEntity> findByControlTowerStatus(@Param("status") VehicleControlTowerStatus status);
 
 }

--- a/core/src/main/java/kernel360/ckt/core/repository/VehicleControlTowerRepository.java
+++ b/core/src/main/java/kernel360/ckt/core/repository/VehicleControlTowerRepository.java
@@ -1,0 +1,21 @@
+package kernel360.ckt.core.repository;
+
+import kernel360.ckt.core.domain.entity.VehicleEntity;
+import kernel360.ckt.core.domain.enums.VehicleControlTowerStatus;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface VehicleControlTowerRepository {
+
+    @Query("SELECT COUNT(v) FROM VehicleEntity v")
+    long countAll();
+
+    @Query("SELECT COUNT(v) FROM VehicleEntity v WHERE v.ControlTowerstatus = :status")
+    long countByStatus(@Param("status") VehicleControlTowerStatus status);
+
+    @Query("SELECT v FROM VehicleEntity v WHERE v.ControlTowerstatus = :status")
+    List<VehicleEntity> findByControlTowerStatus(@Param("status") VehicleControlTowerStatus status);
+
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
<!-- ex) #이슈번호[, #이슈번호] -->

> #26


## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 설명해 주세요. (이미지 첨부 가능) -->

> 실시간 관제를 위해 전체 차량 수, 운행 중 차량의 수, 미운행 차량 수, 미관제 차량 수를 가져오기 위한 개발 진행
> 운행 상태(운행중/미운행/미관제)에 따른 차량을 조회할 수 있는 개발 진행
> VehicleEntity 에 관제 시스템에서 운행중/미운행/미관제 상태 구분하는 컬럼 추가(ControlTowerstatus)


## 👀 리뷰어 가이드라인
<!-- 리뷰어가 중점적으로 확인해야 할 사항을 작성해 주세요. -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

> 불필요하거나 개선되었으면 하는 부분이 있다면 코멘트 부탁드립니다.
