### PR TITLE
feat: 차량 데이터 및 예약 분리 작업 및 예약 관리 기능 추가

### DIFF
--- a/admin/build.gradle
+++ b/admin/build.gradle
@@ -3,6 +3,9 @@ dependencies {
 
     implementation 'org.springframework.boot:spring-boot-starter-web'
 
+    // Validation
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+
     // DB
     implementation 'org.springframework.boot:spring-boot-starter-data-jdbc'
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/admin/src/main/java/kernel360/ckt/admin/application/RentalService.java
+++ b/admin/src/main/java/kernel360/ckt/admin/application/RentalService.java
@@ -1,0 +1,152 @@
+package kernel360.ckt.admin.application;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+import java.util.NoSuchElementException;
+import kernel360.ckt.admin.application.command.CreateRentalCommand;
+import kernel360.ckt.admin.application.command.RentalListCommand;
+import kernel360.ckt.core.domain.entity.CompanyEntity;
+import kernel360.ckt.core.domain.entity.CustomerEntity;
+import kernel360.ckt.core.domain.entity.RentalEntity;
+import kernel360.ckt.core.domain.entity.VehicleEntity;
+import kernel360.ckt.core.domain.enums.RentalStatus;
+import kernel360.ckt.core.repository.CompanyRepository;
+import kernel360.ckt.core.repository.CustomerRepository;
+import kernel360.ckt.core.repository.RentalRepository;
+import kernel360.ckt.core.repository.VehicleRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+@Transactional(readOnly = true)
+public class RentalService {
+    private final RentalRepository rentalRepository;
+    private final CompanyRepository companyRepository;
+    private final VehicleRepository vehicleRepository;
+    private final CustomerRepository customerRepository;
+
+    /**
+     * 새로운 렌탈(예약)을 생성하는 메서드.
+     * Command 객체로부터 필요한 정보를 받아 엔티티를 조회하고, 유효성 검사 후 렌탈 엔티티를 저장한다.
+     *
+     * @param command 렌탈 생성을 위한 데이터를 담고 있는 CreateRentalCommand 객체
+     * @return 생성 및 저장된 RentalEntity 객체
+     * @throws NoSuchElementException 존재하지 않는 회사, 차량, 고객 ID가 전달될 경우 발생
+     * @throws IllegalStateException 해당 시간대에 이미 다른 예약이 존재하여 차량을 대여할 수 없을 경우 발생
+     */
+    @Transactional
+    public RentalEntity createRental(CreateRentalCommand command) {
+        final CompanyEntity company = findCompanyById(command.getCompanyId());
+        final VehicleEntity vehicle = findVehicleById(command.getVehicleId());
+        final CustomerEntity customer = findCustomerById(command.getCustomerId());
+
+        ensureVehicleIsAvailable(vehicle, command.getPickupAt(), command.getReturnAt());
+
+        final RentalEntity rental = RentalEntity.create(
+            company,
+            vehicle,
+            customer,
+            command.getPickupAt(),
+            command.getReturnAt()
+        );
+
+        return rentalRepository.save(rental);
+    }
+
+    /**
+     * 특정 조건에 맞는 렌탈(예약) 목록을 페이징하여 조회합니다.
+     * Company ID, 렌탈 상태, 키워드, 시간 범위 등을 기준으로 필터링할 수 있습니다.
+     *
+     * @param command 렌탈 목록 검색 조건을 담고 있는 RentalListCommand 객체
+     * @param pageable 페이징 및 정렬 정보를 담은 객체
+     * @return 검색 조건에 해당하는 RentalEntity의 페이징된 목록
+     */
+    public Page<RentalEntity> searchRentals(RentalListCommand command, Pageable pageable) {
+        return rentalRepository.search(
+            command.getCompanyId(),
+            command.getStatus(),
+            command.getKeyword(),
+            command.getStartAt(),
+            command.getEndAt(),
+            pageable
+        );
+    }
+
+    /**
+     * ID를 사용하여 단일 렌탈 엔티티를 조회합니다.
+     * 해당 ID의 렌탈이 존재하지 않을 경우 {@link NoSuchElementException}을 발생시킵니다.
+     *
+     * @param id 조회할 렌탈의 ID
+     * @return 해당 ID를 가진 렌탈 엔티티
+     * @throws NoSuchElementException 해당 ID의 렌탈이 존재하지 않을 경우
+     */
+    public RentalEntity findById(Long id) {
+        return rentalRepository.findById(id)
+            .orElseThrow(() -> new NoSuchElementException("예약 정보를 찾을 수 없습니다: " + id));
+    }
+
+    /**
+     * ID로 회사를 조회하고, 없으면 예외를 발생시킵니다.
+     *
+     * @param companyId 조회할 회사의 ID
+     * @return 조회된 CompanyEntity
+     * @throws NoSuchElementException 회사를 찾을 수 없는 경우
+     */
+    private CompanyEntity findCompanyById(Long companyId) {
+        return companyRepository.findById(companyId)
+            .orElseThrow(() -> new NoSuchElementException("회사 정보를 찾을 수 없습니다: " + companyId));
+    }
+
+    /**
+     * ID로 차량을 조회하고, 없으면 예외를 발생시킵니다.
+     *
+     * @param vehicleId 조회할 차량의 ID
+     * @return 조회된 VehicleEntity
+     * @throws NoSuchElementException 차량을 찾을 수 없는 경우
+     */
+    private VehicleEntity findVehicleById(Long vehicleId) {
+        return vehicleRepository.findById(vehicleId)
+            .orElseThrow(() -> new NoSuchElementException("차량 정보를 찾을 수 없습니다: " + vehicleId));
+    }
+
+    /**
+     * ID로 고객을 조회하고, 없으면 예외를 발생시킵니다.
+     *
+     * @param customerId 조회할 고객의 ID
+     * @return 조회된 CustomerEntity
+     * @throws NoSuchElementException 고객을 찾을 수 없는 경우
+     */
+    private CustomerEntity findCustomerById(Long customerId) {
+        return customerRepository.findById(customerId)
+            .orElseThrow(() -> new NoSuchElementException("고객 정보를 찾을 수 없습니다: " + customerId));
+    }
+
+    /**
+     * 특정 차량이 주어진 시간에 대여 가능한지/예약 가능한지 확인합니다.
+     * 중복된 예약이 있으면 예외를 발생시킵니다.
+     *
+     * @param vehicle  확인할 차량 엔티티
+     * @param pickupAt 픽업 시간
+     * @param returnAt 반납 시간
+     * @throws IllegalStateException 해당 시간대에 이미 다른 활성 예약이 존재하는 경우
+     */
+    private void ensureVehicleIsAvailable(VehicleEntity vehicle, LocalDateTime pickupAt, LocalDateTime returnAt) {
+        // PENDING (대기 중) 또는 RENTED (대여 중) 상태의 겹치는 예약을 검사합니다.
+        final List<RentalStatus> activeOrPendingStatuses = Arrays.asList(RentalStatus.PENDING, RentalStatus.RENTED);
+        final List<RentalEntity> overlappingRentals = rentalRepository.findOverlappingRentalsByVehicleAndStatuses(
+            vehicle,
+            activeOrPendingStatuses,
+            pickupAt,
+            returnAt
+        );
+
+        if (!overlappingRentals.isEmpty()) {
+            throw new IllegalStateException("해당 차량은 이미 예약이 존재합니다.");
+        }
+    }
+}

--- a/admin/src/main/java/kernel360/ckt/admin/application/RentalService.java
+++ b/admin/src/main/java/kernel360/ckt/admin/application/RentalService.java
@@ -55,7 +55,8 @@ public class RentalService {
             vehicle,
             customer,
             command.getPickupAt(),
-            command.getReturnAt()
+            command.getReturnAt(),
+            command.getMemo()
         );
 
         return rentalRepository.save(rental);

--- a/admin/src/main/java/kernel360/ckt/admin/application/command/CreateRentalCommand.java
+++ b/admin/src/main/java/kernel360/ckt/admin/application/command/CreateRentalCommand.java
@@ -13,9 +13,10 @@ public class CreateRentalCommand {
     private final Long customerId;
     private final LocalDateTime pickupAt;
     private final LocalDateTime returnAt;
+    private final String memo;
 
-    public static CreateRentalCommand create(Long companyId, Long vehicleId, Long customerId, LocalDateTime pickupAt, LocalDateTime returnAt) {
-        return new CreateRentalCommand(companyId, vehicleId, customerId, pickupAt, returnAt);
+    public static CreateRentalCommand create(Long companyId, Long vehicleId, Long customerId, LocalDateTime pickupAt, LocalDateTime returnAt, String memo) {
+        return new CreateRentalCommand(companyId, vehicleId, customerId, pickupAt, returnAt, memo);
     }
 
 }

--- a/admin/src/main/java/kernel360/ckt/admin/application/command/CreateRentalCommand.java
+++ b/admin/src/main/java/kernel360/ckt/admin/application/command/CreateRentalCommand.java
@@ -1,0 +1,21 @@
+package kernel360.ckt.admin.application.command;
+
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public class CreateRentalCommand {
+    private final Long companyId;
+    private final Long vehicleId;
+    private final Long customerId;
+    private final LocalDateTime pickupAt;
+    private final LocalDateTime returnAt;
+
+    public static CreateRentalCommand create(Long companyId, Long vehicleId, Long customerId, LocalDateTime pickupAt, LocalDateTime returnAt) {
+        return new CreateRentalCommand(companyId, vehicleId, customerId, pickupAt, returnAt);
+    }
+
+}

--- a/admin/src/main/java/kernel360/ckt/admin/application/command/RentalListCommand.java
+++ b/admin/src/main/java/kernel360/ckt/admin/application/command/RentalListCommand.java
@@ -1,0 +1,27 @@
+package kernel360.ckt.admin.application.command;
+
+import java.time.LocalDateTime;
+import kernel360.ckt.core.domain.enums.RentalStatus;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public class RentalListCommand {
+    private final Long companyId;
+    private final RentalStatus status;
+    private final String keyword;
+    private final LocalDateTime startAt;
+    private final LocalDateTime endAt;
+
+    public static RentalListCommand create(
+        Long companyId,
+        RentalStatus status,
+        String keyword,
+        LocalDateTime startAt,
+        LocalDateTime endAt
+    ) {
+        return new RentalListCommand(companyId, status, keyword, startAt, endAt);
+    }
+}

--- a/admin/src/main/java/kernel360/ckt/admin/infra/repository/jpa/DrivingLogJpaRepository.java
+++ b/admin/src/main/java/kernel360/ckt/admin/infra/repository/jpa/DrivingLogJpaRepository.java
@@ -1,0 +1,9 @@
+package kernel360.ckt.admin.infra.repository.jpa;
+
+import kernel360.ckt.core.domain.entity.DrivingLogEntity;
+import kernel360.ckt.core.repository.DrivingLogRepository;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DrivingLogJpaRepository extends JpaRepository<DrivingLogEntity, Long>, DrivingLogRepository {
+
+}

--- a/admin/src/main/java/kernel360/ckt/admin/infra/repository/jpa/RentalJpaRepository.java
+++ b/admin/src/main/java/kernel360/ckt/admin/infra/repository/jpa/RentalJpaRepository.java
@@ -1,0 +1,58 @@
+package kernel360.ckt.admin.infra.repository.jpa;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import kernel360.ckt.core.domain.entity.RentalEntity;
+import kernel360.ckt.core.domain.entity.VehicleEntity;
+import kernel360.ckt.core.domain.enums.RentalStatus;
+import kernel360.ckt.core.repository.RentalRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface RentalJpaRepository extends JpaRepository<RentalEntity, Long>, RentalRepository {
+    @Query("""
+        SELECT r FROM RentalEntity r
+        WHERE r.vehicle = :vehicle
+        AND r.status IN :statuses
+        AND r.pickupAt < :returnAt
+        AND r.returnAt > :pickupAt
+    """)
+    List<RentalEntity> findOverlappingRentalsByVehicleAndStatuses(
+        @Param("vehicle") VehicleEntity vehicle,
+        @Param("statuses") List<RentalStatus> statuses,
+        @Param("pickupAt") LocalDateTime pickupAt,
+        @Param("returnAt") LocalDateTime returnAt
+    );
+
+    @Query("""
+        SELECT r FROM RentalEntity r
+        JOIN FETCH r.customer c
+        JOIN FETCH r.vehicle v
+        JOIN FETCH r.company co
+        WHERE r.company.id = :companyId
+        AND (:status IS NULL OR r.status = :status)
+        AND (:keyword IS NULL
+            OR LOWER(r.customer.customerName) LIKE LOWER(CONCAT('%', :keyword, '%'))
+            OR LOWER(r.vehicle.registrationNumber) LIKE LOWER(CONCAT('%', :keyword, '%'))
+        )
+        AND (:startAt IS NULL OR r.returnAt > :startAt)
+        AND (:endAt IS NULL OR r.pickupAt < :endAt)
+        ORDER BY r.pickupAt DESC
+    """)
+    Page<RentalEntity> search(
+        @Param("companyId") Long companyId,
+        @Param("status") RentalStatus status,
+        @Param("keyword") String keyword,
+        @Param("startAt") LocalDateTime startAt,
+        @Param("endAt") LocalDateTime endAt,
+        Pageable pageable
+    );
+
+    @EntityGraph(attributePaths = {"company", "vehicle", "customer"})
+    Optional<RentalEntity> findById(Long id);
+}

--- a/admin/src/main/java/kernel360/ckt/admin/infra/repository/jpa/RentalJpaRepository.java
+++ b/admin/src/main/java/kernel360/ckt/admin/infra/repository/jpa/RentalJpaRepository.java
@@ -40,8 +40,8 @@ public interface RentalJpaRepository extends JpaRepository<RentalEntity, Long>, 
             OR LOWER(r.customer.customerName) LIKE LOWER(CONCAT('%', :keyword, '%'))
             OR LOWER(r.vehicle.registrationNumber) LIKE LOWER(CONCAT('%', :keyword, '%'))
         )
-        AND (:startAt IS NULL OR r.returnAt > :startAt)
-        AND (:endAt IS NULL OR r.pickupAt < :endAt)
+        AND (:startAt IS NULL OR r.pickupAt > :startAt)
+        AND (:endAt IS NULL OR r.returnAt < :endAt)
         ORDER BY r.pickupAt DESC
     """)
     Page<RentalEntity> search(

--- a/admin/src/main/java/kernel360/ckt/admin/ui/RentalController.java
+++ b/admin/src/main/java/kernel360/ckt/admin/ui/RentalController.java
@@ -1,0 +1,61 @@
+package kernel360.ckt.admin.ui;
+
+import jakarta.validation.Valid;
+import kernel360.ckt.admin.application.RentalService;
+import kernel360.ckt.admin.application.command.CreateRentalCommand;
+import kernel360.ckt.admin.ui.dto.request.RentalCreateRequest;
+import kernel360.ckt.admin.ui.dto.request.RentalListRequest;
+import kernel360.ckt.admin.ui.dto.response.RentalCreateResponse;
+import kernel360.ckt.admin.ui.dto.response.RentalListResponse;
+import kernel360.ckt.admin.ui.dto.response.RentalResponse;
+import kernel360.ckt.core.common.response.CommonResponse;
+import kernel360.ckt.core.domain.entity.RentalEntity;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/rentals")
+@RestController
+public class RentalController {
+    private final RentalService rentalService;
+
+    @PostMapping
+    CommonResponse<RentalCreateResponse> createRental(
+        @RequestHeader("X-User-Id") Long companyId,
+        @Valid @RequestBody RentalCreateRequest request
+    ) {
+        final CreateRentalCommand command = request.toCommand(companyId);
+        final RentalEntity rental = rentalService.createRental(command);
+        return CommonResponse.success(RentalCreateResponse.from(rental));
+    }
+
+    @GetMapping
+    CommonResponse<RentalListResponse> selectRentals(
+        @RequestHeader("X-User-Id") Long companyId,
+        @Validated RentalListRequest request,
+        @PageableDefault(page = 0, size = 10) Pageable pageable
+    ) {
+        final Page<RentalEntity> rentals = rentalService.searchRentals(
+            request.toCommand(companyId),
+            pageable
+        );
+        return CommonResponse.success(RentalListResponse.from(rentals));
+    }
+
+    @GetMapping("/{id}")
+    CommonResponse<RentalResponse> selectRental(@PathVariable Long id) {
+        final RentalEntity rental = rentalService.findById(id);
+        return CommonResponse.success(RentalResponse.from(rental));
+    }
+
+}

--- a/admin/src/main/java/kernel360/ckt/admin/ui/RentalController.java
+++ b/admin/src/main/java/kernel360/ckt/admin/ui/RentalController.java
@@ -5,6 +5,7 @@ import kernel360.ckt.admin.application.RentalService;
 import kernel360.ckt.admin.application.command.CreateRentalCommand;
 import kernel360.ckt.admin.ui.dto.request.RentalCreateRequest;
 import kernel360.ckt.admin.ui.dto.request.RentalListRequest;
+import kernel360.ckt.admin.ui.dto.request.RentalStatusUpdateRequest;
 import kernel360.ckt.admin.ui.dto.response.RentalCreateResponse;
 import kernel360.ckt.admin.ui.dto.response.RentalListResponse;
 import kernel360.ckt.admin.ui.dto.response.RentalResponse;
@@ -16,6 +17,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -56,6 +58,14 @@ public class RentalController {
     CommonResponse<RentalResponse> selectRental(@PathVariable Long id) {
         final RentalEntity rental = rentalService.findById(id);
         return CommonResponse.success(RentalResponse.from(rental));
+    }
+    @PatchMapping("/{id}/status")
+    public CommonResponse<RentalResponse> updateRentalStatus(
+        @PathVariable Long id,
+        @Valid @RequestBody RentalStatusUpdateRequest request
+    ) {
+        final RentalEntity updatedRental = rentalService.updateRentalStatus(id, request.status());
+        return CommonResponse.success(RentalResponse.from(updatedRental));
     }
 
 }

--- a/admin/src/main/java/kernel360/ckt/admin/ui/dto/request/RentalCreateRequest.java
+++ b/admin/src/main/java/kernel360/ckt/admin/ui/dto/request/RentalCreateRequest.java
@@ -18,7 +18,9 @@ public record RentalCreateRequest(
 
     @NotNull(message = "반납 시간은 필수입니다.")
     @FutureOrPresent(message = "반납 시간은 현재보다 미래여야 합니다.")
-    LocalDateTime returnAt
+    LocalDateTime returnAt,
+
+    String memo
 ) {
     public RentalCreateRequest {
         if (pickupAt != null && returnAt != null && pickupAt.isAfter(returnAt)) {
@@ -32,7 +34,8 @@ public record RentalCreateRequest(
             vehicleId,
             customerId,
             pickupAt,
-            returnAt
+            returnAt,
+            memo
         );
     }
 }

--- a/admin/src/main/java/kernel360/ckt/admin/ui/dto/request/RentalCreateRequest.java
+++ b/admin/src/main/java/kernel360/ckt/admin/ui/dto/request/RentalCreateRequest.java
@@ -1,0 +1,38 @@
+package kernel360.ckt.admin.ui.dto.request;
+
+import jakarta.validation.constraints.FutureOrPresent;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDateTime;
+import kernel360.ckt.admin.application.command.CreateRentalCommand;
+
+public record RentalCreateRequest(
+    @NotNull(message = "차량은 필수입니다.")
+    Long vehicleId,
+
+    @NotNull(message = "고객은 필수입니다.")
+    Long customerId,
+
+    @NotNull(message = "픽업 시간은 필수입니다.")
+    @FutureOrPresent(message = "픽업 시간은 현재보다 미래여야 합니다.")
+    LocalDateTime pickupAt,
+
+    @NotNull(message = "반납 시간은 필수입니다.")
+    @FutureOrPresent(message = "반납 시간은 현재보다 미래여야 합니다.")
+    LocalDateTime returnAt
+) {
+    public RentalCreateRequest {
+        if (pickupAt != null && returnAt != null && pickupAt.isAfter(returnAt)) {
+            throw new IllegalArgumentException("반납 시간은 픽업 시간보다 이후여야 합니다.");
+        }
+    }
+
+    public CreateRentalCommand toCommand(Long companyId) {
+        return CreateRentalCommand.create(
+            companyId,
+            vehicleId,
+            customerId,
+            pickupAt,
+            returnAt
+        );
+    }
+}

--- a/admin/src/main/java/kernel360/ckt/admin/ui/dto/request/RentalListRequest.java
+++ b/admin/src/main/java/kernel360/ckt/admin/ui/dto/request/RentalListRequest.java
@@ -1,0 +1,33 @@
+package kernel360.ckt.admin.ui.dto.request;
+
+import java.time.LocalDateTime;
+import kernel360.ckt.admin.application.command.RentalListCommand;
+import kernel360.ckt.core.domain.enums.RentalStatus;
+import org.springframework.format.annotation.DateTimeFormat;
+
+public record RentalListRequest(
+    RentalStatus status,
+    String keyword,
+
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    LocalDateTime startAt,
+
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    LocalDateTime endAt
+) {
+    public RentalListRequest {
+        if (startAt != null && endAt != null && startAt.isAfter(endAt)) {
+            throw new IllegalArgumentException("검색 시작 시간은 종료 시간보다 이후일 수 없습니다.");
+        }
+    }
+
+    public RentalListCommand toCommand(Long companyId) {
+        return RentalListCommand.create(
+            companyId,
+            this.status,
+            this.keyword,
+            this.startAt,
+            this.endAt
+        );
+    }
+}

--- a/admin/src/main/java/kernel360/ckt/admin/ui/dto/request/RentalStatusUpdateRequest.java
+++ b/admin/src/main/java/kernel360/ckt/admin/ui/dto/request/RentalStatusUpdateRequest.java
@@ -1,0 +1,11 @@
+package kernel360.ckt.admin.ui.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import kernel360.ckt.core.domain.enums.RentalStatus;
+
+public record RentalStatusUpdateRequest(
+    @NotNull(message = "변경할 상태는 필수입니다.")
+    RentalStatus status
+) {
+
+}

--- a/admin/src/main/java/kernel360/ckt/admin/ui/dto/response/RentalCreateResponse.java
+++ b/admin/src/main/java/kernel360/ckt/admin/ui/dto/response/RentalCreateResponse.java
@@ -1,0 +1,11 @@
+package kernel360.ckt.admin.ui.dto.response;
+
+import kernel360.ckt.core.domain.entity.RentalEntity;
+
+public record RentalCreateResponse(
+    Long id
+) {
+    public static RentalCreateResponse from(RentalEntity rental) {
+        return new RentalCreateResponse(rental.getId());
+    }
+}

--- a/admin/src/main/java/kernel360/ckt/admin/ui/dto/response/RentalListResponse.java
+++ b/admin/src/main/java/kernel360/ckt/admin/ui/dto/response/RentalListResponse.java
@@ -1,0 +1,28 @@
+package kernel360.ckt.admin.ui.dto.response;
+
+import java.util.List;
+import kernel360.ckt.core.domain.entity.RentalEntity;
+import org.springframework.data.domain.Page;
+
+public record RentalListResponse(
+    List<RentalSummaryResponse> list,
+    int page,
+    int size,
+    long totalElements,
+    int totalPages
+){
+    public static RentalListResponse from(Page<RentalEntity> pageData) {
+        List<RentalSummaryResponse> rentals = pageData.getContent()
+            .stream()
+            .map(RentalSummaryResponse::from)
+            .toList();
+
+        return new RentalListResponse(
+            rentals,
+            pageData.getNumber(),
+            pageData.getSize(),
+            pageData.getTotalElements(),
+            pageData.getTotalPages()
+        );
+    }
+}

--- a/admin/src/main/java/kernel360/ckt/admin/ui/dto/response/RentalResponse.java
+++ b/admin/src/main/java/kernel360/ckt/admin/ui/dto/response/RentalResponse.java
@@ -13,7 +13,8 @@ public record RentalResponse(
     String customerPhoneNumber,
     String vehicleRegistrationNumber,
     String vehicleModelName,
-    String vehicleManufactureYear,
+    String vehicleManufacture,
+    String vehicleModelYear,
     RentalStatus rentalStatus,
     String rentalStatusName,
     LocalDateTime pickupAt,
@@ -29,8 +30,12 @@ public record RentalResponse(
             .map(VehicleEntity::getModelName)
             .orElse(null);
 
-        final String vehicleManufactureYear = Optional.ofNullable(rentalEntity.getVehicle())
+        final String vehicleManufacture = Optional.ofNullable(rentalEntity.getVehicle())
             .map(VehicleEntity::getManufacturer)
+            .orElse(null);
+
+        final String vehicleModelYear = Optional.ofNullable(rentalEntity.getVehicle())
+            .map(VehicleEntity::getModelYear)
             .orElse(null);
 
         final String customerName = Optional.ofNullable(rentalEntity.getCustomer())
@@ -47,7 +52,8 @@ public record RentalResponse(
             customerPhoneNumber,
             vehicleRegistrationNumber,
             vehicleModelName,
-            vehicleManufactureYear,
+            vehicleManufacture,
+            vehicleModelYear,
             rentalEntity.getStatus(),
             rentalEntity.getStatus().getValue(),
             rentalEntity.getPickupAt(),

--- a/admin/src/main/java/kernel360/ckt/admin/ui/dto/response/RentalResponse.java
+++ b/admin/src/main/java/kernel360/ckt/admin/ui/dto/response/RentalResponse.java
@@ -1,0 +1,56 @@
+package kernel360.ckt.admin.ui.dto.response;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+import kernel360.ckt.core.domain.entity.CustomerEntity;
+import kernel360.ckt.core.domain.entity.RentalEntity;
+import kernel360.ckt.core.domain.entity.VehicleEntity;
+import kernel360.ckt.core.domain.enums.RentalStatus;
+
+public record RentalResponse(
+    Long id,
+    String customerName,
+    String customerPhoneNumber,
+    String vehicleRegistrationNumber,
+    String vehicleModelName,
+    String vehicleManufactureYear,
+    RentalStatus rentalStatus,
+    String rentalStatusName,
+    LocalDateTime pickupAt,
+    LocalDateTime returnAt
+) {
+    public static RentalResponse from(RentalEntity rentalEntity) {
+        final String vehicleRegistrationNumber = Optional.ofNullable(rentalEntity.getVehicle())
+            .map(VehicleEntity::getRegistrationNumber)
+            .orElse(null);
+
+        final String vehicleModelName = Optional.ofNullable(rentalEntity.getVehicle())
+            .map(VehicleEntity::getModelName)
+            .orElse(null);
+
+        final String vehicleManufactureYear = Optional.ofNullable(rentalEntity.getVehicle())
+            .map(VehicleEntity::getManufacturer)
+            .orElse(null);
+
+        final String customerName = Optional.ofNullable(rentalEntity.getCustomer())
+            .map(CustomerEntity::getCustomerName)
+            .orElse(null);
+
+        final String customerPhoneNumber = Optional.ofNullable(rentalEntity.getCustomer())
+            .map(CustomerEntity::getPhoneNumber)
+            .orElse(null);
+
+        return new RentalResponse(
+            rentalEntity.getId(),
+            customerName,
+            customerPhoneNumber,
+            vehicleRegistrationNumber,
+            vehicleModelName,
+            vehicleManufactureYear,
+            rentalEntity.getStatus(),
+            rentalEntity.getStatus().getValue(),
+            rentalEntity.getPickupAt(),
+            rentalEntity.getReturnAt()
+        );
+    }
+}

--- a/admin/src/main/java/kernel360/ckt/admin/ui/dto/response/RentalResponse.java
+++ b/admin/src/main/java/kernel360/ckt/admin/ui/dto/response/RentalResponse.java
@@ -17,7 +17,8 @@ public record RentalResponse(
     RentalStatus rentalStatus,
     String rentalStatusName,
     LocalDateTime pickupAt,
-    LocalDateTime returnAt
+    LocalDateTime returnAt,
+    String memo
 ) {
     public static RentalResponse from(RentalEntity rentalEntity) {
         final String vehicleRegistrationNumber = Optional.ofNullable(rentalEntity.getVehicle())
@@ -50,7 +51,8 @@ public record RentalResponse(
             rentalEntity.getStatus(),
             rentalEntity.getStatus().getValue(),
             rentalEntity.getPickupAt(),
-            rentalEntity.getReturnAt()
+            rentalEntity.getReturnAt(),
+            rentalEntity.getMemo()
         );
     }
 }

--- a/admin/src/main/java/kernel360/ckt/admin/ui/dto/response/RentalSummaryResponse.java
+++ b/admin/src/main/java/kernel360/ckt/admin/ui/dto/response/RentalSummaryResponse.java
@@ -1,0 +1,56 @@
+package kernel360.ckt.admin.ui.dto.response;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+import kernel360.ckt.core.domain.entity.CustomerEntity;
+import kernel360.ckt.core.domain.entity.RentalEntity;
+import kernel360.ckt.core.domain.entity.VehicleEntity;
+import kernel360.ckt.core.domain.enums.RentalStatus;
+
+public record RentalSummaryResponse(
+    Long id,
+    String customerName,
+    String customerPhoneNumber,
+    String vehicleRegistrationNumber,
+    String vehicleModelName,
+    String vehicleManufactureYear,
+    RentalStatus rentalStatus,
+    String rentalStatusName,
+    LocalDateTime pickupAt,
+    LocalDateTime returnAt
+) {
+    public static RentalSummaryResponse from(RentalEntity rentalEntity) {
+        final String vehicleRegistrationNumber = Optional.ofNullable(rentalEntity.getVehicle())
+            .map(VehicleEntity::getRegistrationNumber)
+            .orElse(null);
+
+        final String vehicleModelName = Optional.ofNullable(rentalEntity.getVehicle())
+            .map(VehicleEntity::getModelName)
+            .orElse(null);
+
+        final String vehicleManufactureYear = Optional.ofNullable(rentalEntity.getVehicle())
+            .map(VehicleEntity::getManufacturer)
+            .orElse(null);
+
+        final String customerName = Optional.ofNullable(rentalEntity.getCustomer())
+            .map(CustomerEntity::getCustomerName)
+            .orElse(null);
+
+        final String customerPhoneNumber = Optional.ofNullable(rentalEntity.getCustomer())
+            .map(CustomerEntity::getPhoneNumber)
+            .orElse(null);
+
+        return new RentalSummaryResponse(
+            rentalEntity.getId(),
+            customerName,
+            customerPhoneNumber,
+            vehicleRegistrationNumber,
+            vehicleModelName,
+            vehicleManufactureYear,
+            rentalEntity.getStatus(),
+            rentalEntity.getStatus().getValue(),
+            rentalEntity.getPickupAt(),
+            rentalEntity.getReturnAt()
+        );
+    }
+}

--- a/admin/src/main/java/kernel360/ckt/admin/ui/dto/response/RentalSummaryResponse.java
+++ b/admin/src/main/java/kernel360/ckt/admin/ui/dto/response/RentalSummaryResponse.java
@@ -13,7 +13,8 @@ public record RentalSummaryResponse(
     String customerPhoneNumber,
     String vehicleRegistrationNumber,
     String vehicleModelName,
-    String vehicleManufactureYear,
+    String vehicleManufacture,
+    String vehicleModelYear,
     RentalStatus rentalStatus,
     String rentalStatusName,
     LocalDateTime pickupAt,
@@ -29,8 +30,12 @@ public record RentalSummaryResponse(
             .map(VehicleEntity::getModelName)
             .orElse(null);
 
-        final String vehicleManufactureYear = Optional.ofNullable(rentalEntity.getVehicle())
+        final String vehicleManufacture = Optional.ofNullable(rentalEntity.getVehicle())
             .map(VehicleEntity::getManufacturer)
+            .orElse(null);
+
+        final String vehicleModelYear = Optional.ofNullable(rentalEntity.getVehicle())
+            .map(VehicleEntity::getModelYear)
             .orElse(null);
 
         final String customerName = Optional.ofNullable(rentalEntity.getCustomer())
@@ -47,7 +52,8 @@ public record RentalSummaryResponse(
             customerPhoneNumber,
             vehicleRegistrationNumber,
             vehicleModelName,
-            vehicleManufactureYear,
+            vehicleManufacture,
+            vehicleModelYear,
             rentalEntity.getStatus(),
             rentalEntity.getStatus().getValue(),
             rentalEntity.getPickupAt(),

--- a/admin/src/main/java/kernel360/ckt/admin/ui/dto/response/RentalSummaryResponse.java
+++ b/admin/src/main/java/kernel360/ckt/admin/ui/dto/response/RentalSummaryResponse.java
@@ -17,7 +17,8 @@ public record RentalSummaryResponse(
     RentalStatus rentalStatus,
     String rentalStatusName,
     LocalDateTime pickupAt,
-    LocalDateTime returnAt
+    LocalDateTime returnAt,
+    String memo
 ) {
     public static RentalSummaryResponse from(RentalEntity rentalEntity) {
         final String vehicleRegistrationNumber = Optional.ofNullable(rentalEntity.getVehicle())
@@ -50,7 +51,8 @@ public record RentalSummaryResponse(
             rentalEntity.getStatus(),
             rentalEntity.getStatus().getValue(),
             rentalEntity.getPickupAt(),
-            rentalEntity.getReturnAt()
+            rentalEntity.getReturnAt(),
+            rentalEntity.getMemo()
         );
     }
 }

--- a/collector/src/main/java/kernel360/ckt/collector/CollectorApplication.java
+++ b/collector/src/main/java/kernel360/ckt/collector/CollectorApplication.java
@@ -3,11 +3,9 @@ package kernel360.ckt.collector;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
-import org.springframework.context.annotation.ComponentScan;
 
 
 @EntityScan(basePackages = "kernel360.ckt.core")
-@ComponentScan(basePackages = {"kernel360.ckt.core", "kernel360.ckt.collector"})
 @SpringBootApplication
 public class CollectorApplication {
     public static void main(String[] args) {

--- a/collector/src/main/java/kernel360/ckt/collector/application/VehicleCollectorService.java
+++ b/collector/src/main/java/kernel360/ckt/collector/application/VehicleCollectorService.java
@@ -25,15 +25,15 @@ public class VehicleCollectorService {
 
     @Transactional
     public VehicleCollectorResponse sendVehicleOn(VehicleCollectorOnCommand command) {
-        final VehicleEntity vehicle = vehicleService.findById(command.getVehicleId());
-
-        final RentalEntity rental = rentalRepository.save(command.toRentalEntity(vehicle));
-
-        final DrivingLogEntity drivingLog = command.toDrivingLogentity(rental, vehicle);
-        drivingLog.inProgress();
-
-        final DrivingLogEntity savedDrivingLog = drivingLogRepository.save(drivingLog);
-        routeRepository.save(command.toRouteEntity(savedDrivingLog));
+//        final VehicleEntity vehicle = vehicleService.findById(command.getVehicleId());
+//
+//        final RentalEntity rental = rentalRepository.save(command.toRentalEntity(vehicle));
+//
+//        final DrivingLogEntity drivingLog = command.toDrivingLogentity(rental, vehicle);
+//        drivingLog.inProgress();
+//
+//        final DrivingLogEntity savedDrivingLog = drivingLogRepository.save(drivingLog);
+//        routeRepository.save(command.toRouteEntity(savedDrivingLog));
 
         return VehicleCollectorResponse.from(command.getVehicleId());
     }

--- a/collector/src/main/java/kernel360/ckt/collector/application/command/VehicleCollectorOnCommand.java
+++ b/collector/src/main/java/kernel360/ckt/collector/application/command/VehicleCollectorOnCommand.java
@@ -1,11 +1,13 @@
 package kernel360.ckt.collector.application.command;
 
-import kernel360.ckt.core.domain.entity.*;
+import java.time.LocalDateTime;
+import kernel360.ckt.core.domain.entity.DrivingLogEntity;
+import kernel360.ckt.core.domain.entity.RentalEntity;
+import kernel360.ckt.core.domain.entity.RouteEntity;
+import kernel360.ckt.core.domain.entity.VehicleEntity;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-
-import java.time.LocalDateTime;
 
 @Getter
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
@@ -30,10 +32,6 @@ public class VehicleCollectorOnCommand {
         LocalDateTime onTime
     ) {
         return new VehicleCollectorOnCommand(vehicleId, gcd, lat, lon, direction, speed, totalDistance, onTime);
-    }
-
-    public RentalEntity toRentalEntity(VehicleEntity vehicle) {
-        return RentalEntity.create(vehicle, this.onTime);
     }
 
     public DrivingLogEntity toDrivingLogentity(RentalEntity rental, VehicleEntity vehicle) {

--- a/collector/src/main/java/kernel360/ckt/collector/application/repository/DrivingLogRepository.java
+++ b/collector/src/main/java/kernel360/ckt/collector/application/repository/DrivingLogRepository.java
@@ -1,0 +1,12 @@
+package kernel360.ckt.collector.application.repository;
+
+import java.util.Optional;
+import kernel360.ckt.core.domain.entity.DrivingLogEntity;
+import kernel360.ckt.core.domain.enums.DrivingLogStatus;
+
+public interface DrivingLogRepository {
+    DrivingLogEntity save(DrivingLogEntity drivingLog);
+
+    Optional<DrivingLogEntity> findFirstByVehicleIdAndStatusOrderByCreateAtDesc(Long vehicleId, DrivingLogStatus status);
+    Optional<DrivingLogEntity> findFirstByRentalIdAndStatus(Long rentalId, DrivingLogStatus status);
+}

--- a/collector/src/main/java/kernel360/ckt/collector/application/repository/DrivingLogRepository.java
+++ b/collector/src/main/java/kernel360/ckt/collector/application/repository/DrivingLogRepository.java
@@ -2,11 +2,13 @@ package kernel360.ckt.collector.application.repository;
 
 import java.util.Optional;
 import kernel360.ckt.core.domain.entity.DrivingLogEntity;
+import kernel360.ckt.core.domain.entity.RentalEntity;
+import kernel360.ckt.core.domain.entity.VehicleEntity;
 import kernel360.ckt.core.domain.enums.DrivingLogStatus;
 
 public interface DrivingLogRepository {
     DrivingLogEntity save(DrivingLogEntity drivingLog);
+    Optional<DrivingLogEntity> findFirstByRentalAndStatus(RentalEntity rental, DrivingLogStatus status);
+    Optional<DrivingLogEntity> findFirstByVehicleAndStatusOrderByCreatedAtDesc(VehicleEntity vehicle, DrivingLogStatus status);
 
-    Optional<DrivingLogEntity> findFirstByVehicleIdAndStatusOrderByCreateAtDesc(Long vehicleId, DrivingLogStatus status);
-    Optional<DrivingLogEntity> findFirstByRentalIdAndStatus(Long rentalId, DrivingLogStatus status);
 }

--- a/collector/src/main/java/kernel360/ckt/collector/application/repository/RentalRepository.java
+++ b/collector/src/main/java/kernel360/ckt/collector/application/repository/RentalRepository.java
@@ -1,0 +1,12 @@
+package kernel360.ckt.collector.application.repository;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+import kernel360.ckt.core.domain.entity.RentalEntity;
+import kernel360.ckt.core.domain.enums.RentalStatus;
+
+public interface RentalRepository {
+
+    Optional<RentalEntity> findFirstByVehicleIdAndStatusAndPickupAt(Long vehicleId, RentalStatus status, LocalDateTime pickupAt);
+
+}

--- a/collector/src/main/java/kernel360/ckt/collector/application/repository/RentalRepository.java
+++ b/collector/src/main/java/kernel360/ckt/collector/application/repository/RentalRepository.java
@@ -7,6 +7,6 @@ import kernel360.ckt.core.domain.enums.RentalStatus;
 
 public interface RentalRepository {
 
-    Optional<RentalEntity> findFirstByVehicleIdAndStatusAndPickupAt(Long vehicleId, RentalStatus status, LocalDateTime pickupAt);
+    Optional<RentalEntity> findActiveRental(Long vehicleId, LocalDateTime onTime, RentalStatus status);
 
 }

--- a/collector/src/main/java/kernel360/ckt/collector/application/repository/RouteRepository.java
+++ b/collector/src/main/java/kernel360/ckt/collector/application/repository/RouteRepository.java
@@ -1,0 +1,10 @@
+package kernel360.ckt.collector.application.repository;
+
+import java.util.Optional;
+import kernel360.ckt.core.domain.entity.RouteEntity;
+import kernel360.ckt.core.domain.enums.RouteStatus;
+
+public interface RouteRepository {
+    RouteEntity save(RouteEntity route);
+    Optional<RouteEntity> findFirstByDrivingLogIdAndStatusOrderByStartAtDesc(Long drivingLogId, RouteStatus routeStatus);
+}

--- a/collector/src/main/java/kernel360/ckt/collector/application/repository/RouteRepository.java
+++ b/collector/src/main/java/kernel360/ckt/collector/application/repository/RouteRepository.java
@@ -1,10 +1,11 @@
 package kernel360.ckt.collector.application.repository;
 
 import java.util.Optional;
+import kernel360.ckt.core.domain.entity.DrivingLogEntity;
 import kernel360.ckt.core.domain.entity.RouteEntity;
 import kernel360.ckt.core.domain.enums.RouteStatus;
 
 public interface RouteRepository {
     RouteEntity save(RouteEntity route);
-    Optional<RouteEntity> findFirstByDrivingLogIdAndStatusOrderByStartAtDesc(Long drivingLogId, RouteStatus routeStatus);
+    Optional<RouteEntity> findFirstByDrivingLogAndStatusOrderByStartAtDesc(DrivingLogEntity drivingLog, RouteStatus routeStatus);
 }

--- a/collector/src/main/java/kernel360/ckt/collector/application/repository/VehicleRepository.java
+++ b/collector/src/main/java/kernel360/ckt/collector/application/repository/VehicleRepository.java
@@ -1,0 +1,15 @@
+package kernel360.ckt.collector.application.repository;
+
+import java.util.Optional;
+import kernel360.ckt.core.domain.entity.VehicleEntity;
+import kernel360.ckt.core.domain.enums.VehicleStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface VehicleRepository {
+    VehicleEntity save(VehicleEntity vehicleEntity);
+    void deleteById(Long vehicleId);
+    Page<VehicleEntity> findAll(Pageable pageable);
+    Page<VehicleEntity> search(VehicleStatus status, String keyword, Pageable pageable);
+    Optional<VehicleEntity> findById(Long vehicleId);
+}

--- a/collector/src/main/java/kernel360/ckt/collector/application/repository/VehicleTraceLogRepository.java
+++ b/collector/src/main/java/kernel360/ckt/collector/application/repository/VehicleTraceLogRepository.java
@@ -1,0 +1,7 @@
+package kernel360.ckt.collector.application.repository;
+
+import kernel360.ckt.core.domain.entity.VehicleTraceLogEntity;
+
+public interface VehicleTraceLogRepository {
+    VehicleTraceLogEntity save(VehicleTraceLogEntity vehicleTraceLog);
+}

--- a/collector/src/main/java/kernel360/ckt/collector/application/service/VehicleCollectorService.java
+++ b/collector/src/main/java/kernel360/ckt/collector/application/service/VehicleCollectorService.java
@@ -1,6 +1,8 @@
 package kernel360.ckt.collector.application.service;
 
+import jakarta.persistence.EntityNotFoundException;
 import jakarta.transaction.Transactional;
+import java.util.Optional;
 import kernel360.ckt.collector.application.repository.DrivingLogRepository;
 import kernel360.ckt.collector.application.repository.RentalRepository;
 import kernel360.ckt.collector.application.repository.RouteRepository;
@@ -9,7 +11,11 @@ import kernel360.ckt.collector.application.service.command.VehicleCollectorCycle
 import kernel360.ckt.collector.application.service.command.VehicleCollectorOffCommand;
 import kernel360.ckt.collector.application.service.command.VehicleCollectorOnCommand;
 import kernel360.ckt.collector.ui.dto.response.VehicleCollectorResponse;
-import kernel360.ckt.core.domain.entity.*;
+import kernel360.ckt.core.domain.entity.DrivingLogEntity;
+import kernel360.ckt.core.domain.entity.RentalEntity;
+import kernel360.ckt.core.domain.entity.RouteEntity;
+import kernel360.ckt.core.domain.entity.VehicleEntity;
+import kernel360.ckt.core.domain.entity.VehicleTraceLogEntity;
 import kernel360.ckt.core.domain.enums.DrivingLogStatus;
 import kernel360.ckt.core.domain.enums.RentalStatus;
 import kernel360.ckt.core.domain.enums.RouteStatus;
@@ -26,60 +32,101 @@ public class VehicleCollectorService {
     private final RouteRepository routeRepository;
     private final VehicleTraceLogRepository vehicleTraceLogRepository;
 
+    /**
+     * 차량 운행을 시작합니다.
+     * 활성 렌탈을 확인하고, 기존 운행일지가 없으면 새로 생성하며, 항상 새로운 경로를 시작합니다.
+     */
     @Transactional
     public VehicleCollectorResponse sendVehicleOn(VehicleCollectorOnCommand command) {
-//        final VehicleEntity vehicle = vehicleService.findById(command.getVehicleId());
-//
-//        final RentalEntity rental = rentalRepository.save(command.toRentalEntity(vehicle));
-//
-//        final DrivingLogEntity drivingLog = command.toDrivingLogentity(rental, vehicle);
-//        drivingLog.inProgress();
-//
-//        final DrivingLogEntity savedDrivingLog = drivingLogRepository.save(drivingLog);
-//        routeRepository.save(command.toRouteEntity(savedDrivingLog));
+        final VehicleEntity vehicle = vehicleService.findById(command.getVehicleId());
+
+        // 예약 여부를 확인합니다.
+        final RentalEntity rental = rentalRepository.findActiveRental(vehicle.getId(), command.getOnTime(), RentalStatus.RENTED)
+            .orElseThrow(() -> new EntityNotFoundException("예약된 차량이 아닙니다."));
+
+        // 진행 중인 운행일지가 존재하는지 찾습니다.
+        Optional<DrivingLogEntity> existingDrivingLog = drivingLogRepository.findFirstByRentalAndStatus(rental, DrivingLogStatus.IN_PROGRESS);
+
+        final DrivingLogEntity drivingLog;
+        if (existingDrivingLog.isPresent()) {
+            // 기존 운행일지가 있다면 재사용 (하나의 렌탈 당 하나의 운행일지 유지)
+            drivingLog = existingDrivingLog.get();
+        } else {
+            // 기존 운행일지가 없다면 새로 생성하여 IN_PROGRESS 상태로 저장
+            final DrivingLogEntity newDrivingLog = command.toDrivingLogEntity(rental, vehicle);
+            newDrivingLog.inProgress();
+            drivingLog = drivingLogRepository.save(newDrivingLog);
+        }
+
+        // 새로운 경로 시작
+        routeRepository.save(command.toRouteEntity(drivingLog));
 
         return VehicleCollectorResponse.from(command.getVehicleId());
     }
 
+    /**
+     * 차량 운행을 종료합니다.
+     * 진행 중인 운행일지와 활성 경로를 찾아 경로를 완료 처리합니다. (운행일지 자체는 완료하지 않음)
+     */
     @Transactional
     public VehicleCollectorResponse sendVehicleOff(VehicleCollectorOffCommand command) {
         final VehicleEntity vehicle = vehicleService.findById(command.getVehicleId());
 
-//        final RentalEntity rental = rentalRepository.findFirstByVehicleIdAndStatusAndPickupAt(vehicle.getId(), RentalStatus.RENTED, command.getOnTime())
-//            .orElseThrow(() -> new RuntimeException("렌탈 정보를 찾을 수 없습니다."));
-//        rental.returned(command.getOnTime());
-//        rentalRepository.save(rental);
+        // 진행 중인 운행일지를 찾습니다.
+        final DrivingLogEntity drivingLog = findActiveDrivingLog(vehicle);
 
-//        final DrivingLogEntity drivingLog = drivingLogRepository.findFirstByRentalIdAndStatus(rental.getId(), DrivingLogStatus.IN_PROGRESS)
-//            .orElseThrow(() -> new RuntimeException("운행 일지 정보를 찾을 수 없습니다."));
-//
-//        drivingLog.completed();
-//        drivingLogRepository.save(drivingLog);
-//
-//        final RouteEntity route = routeRepository.findFirstByDrivingLogIdAndStatusOrderByStartAtDesc(drivingLog.getId(), RouteStatus.ACTIVE)
-//            .orElseThrow(() -> new RuntimeException("경로 정보를 찾을 수 없습니다."));
-//        route.completed(command.getLat(), command.getLon(), command.getTotalDistance(), command.getOffTime());
-//        routeRepository.save(route);
+        // 해당 운행일지에 연결된 활성 경로를 찾습니다.
+        final RouteEntity route = findActiveRoute(drivingLog);
+
+        // 경로를 완료 상태로 업데이트하고 저장
+        route.completed(command.getLat(), command.getLon(), command.getTotalDistance(), command.getOffTime());
+        routeRepository.save(route);
 
         return VehicleCollectorResponse.from(command.getVehicleId());
     }
 
+    /**
+     * 운행 중 차량의 주기 정보를 저장합니다.
+     * 진행 중인 운행일지와 활성 경로를 찾아 해당 정보를 기록합니다.
+     */
     @Transactional
     public VehicleCollectorResponse saveVehicleCycle(VehicleCollectorCycleCommand command) {
         final VehicleEntity vehicle = vehicleService.findById(command.getVehicleId());
 
-        final DrivingLogEntity drivingLog = drivingLogRepository.findFirstByVehicleIdAndStatusOrderByCreateAtDesc(vehicle.getId(), DrivingLogStatus.IN_PROGRESS)
-            .orElseThrow(() -> new RuntimeException("운행 일지 정보를 찾을 수 없습니다."));
+        // 진행 중인 운행일지를 찾습니다.
+        final DrivingLogEntity drivingLog = findActiveDrivingLog(vehicle);
 
-        drivingLogRepository.save(drivingLog);
+        // 해당 운행일지에 연결된 활성 경로를 찾습니다.
+        final RouteEntity route = findActiveRoute(drivingLog);
 
-        final RouteEntity route = routeRepository.findFirstByDrivingLogIdAndStatusOrderByStartAtDesc(drivingLog.getId(), RouteStatus.ACTIVE)
-            .orElseThrow(() -> new RuntimeException("경로 정보를 찾을 수 없습니다."));
-
+        // 새로운 차량 추적 로그를 생성하고 저장
         VehicleTraceLogEntity vehicleTraceLog = VehicleTraceLogEntity.create(route, command.getCList(), command.getOnTime());
         vehicleTraceLogRepository.save(vehicleTraceLog);
 
         return VehicleCollectorResponse.from(command.getVehicleId());
     }
 
+    /**
+     * 특정 차량에 대해 진행 중인 운행일지(DrivingLog)를 찾습니다.
+     *
+     * @param vehicle 운행일지를 찾을 대상 차량 엔티티
+     * @return 찾은 DrivingLogEntity 객체
+     * @throws EntityNotFoundException 진행 중인 운행일지를 찾을 수 없을 경우
+     */
+    private DrivingLogEntity findActiveDrivingLog(VehicleEntity vehicle) {
+        return drivingLogRepository.findFirstByVehicleAndStatusOrderByCreatedAtDesc(vehicle, DrivingLogStatus.IN_PROGRESS)
+            .orElseThrow(() -> new EntityNotFoundException("운행 일지 정보를 찾을 수 없습니다."));
+    }
+
+    /**
+     * 특정 운행일지(DrivingLog)에 연결된 활성 경로(Route)를 찾습니다.
+     *
+     * @param drivingLog 활성 경로를 찾을 대상 운행일지 엔티티
+     * @return 찾은 RouteEntity 객체
+     * @throws EntityNotFoundException 활성 경로를 찾을 수 없을 경우
+     */
+    private RouteEntity findActiveRoute(DrivingLogEntity drivingLog) {
+        return routeRepository.findFirstByDrivingLogAndStatusOrderByStartAtDesc(drivingLog, RouteStatus.ACTIVE)
+            .orElseThrow(() -> new EntityNotFoundException("경로 정보를 찾을 수 없습니다."));
+    }
 }

--- a/collector/src/main/java/kernel360/ckt/collector/application/service/VehicleCollectorService.java
+++ b/collector/src/main/java/kernel360/ckt/collector/application/service/VehicleCollectorService.java
@@ -1,15 +1,18 @@
-package kernel360.ckt.collector.application;
+package kernel360.ckt.collector.application.service;
 
 import jakarta.transaction.Transactional;
-import kernel360.ckt.collector.application.command.VehicleCollectorCycleCommand;
-import kernel360.ckt.collector.application.command.VehicleCollectorOffCommand;
-import kernel360.ckt.collector.application.command.VehicleCollectorOnCommand;
+import kernel360.ckt.collector.application.repository.DrivingLogRepository;
+import kernel360.ckt.collector.application.repository.RentalRepository;
+import kernel360.ckt.collector.application.repository.RouteRepository;
+import kernel360.ckt.collector.application.repository.VehicleTraceLogRepository;
+import kernel360.ckt.collector.application.service.command.VehicleCollectorCycleCommand;
+import kernel360.ckt.collector.application.service.command.VehicleCollectorOffCommand;
+import kernel360.ckt.collector.application.service.command.VehicleCollectorOnCommand;
 import kernel360.ckt.collector.ui.dto.response.VehicleCollectorResponse;
 import kernel360.ckt.core.domain.entity.*;
 import kernel360.ckt.core.domain.enums.DrivingLogStatus;
 import kernel360.ckt.core.domain.enums.RentalStatus;
 import kernel360.ckt.core.domain.enums.RouteStatus;
-import kernel360.ckt.core.repository.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -42,21 +45,21 @@ public class VehicleCollectorService {
     public VehicleCollectorResponse sendVehicleOff(VehicleCollectorOffCommand command) {
         final VehicleEntity vehicle = vehicleService.findById(command.getVehicleId());
 
-        final RentalEntity rental = rentalRepository.findFirstByVehicleIdAndStatusAndPickupAt(vehicle.getId(), RentalStatus.RENTED, command.getOnTime())
-            .orElseThrow(() -> new RuntimeException("렌탈 정보를 찾을 수 없습니다."));
-        rental.returned(command.getOnTime());
-        rentalRepository.save(rental);
+//        final RentalEntity rental = rentalRepository.findFirstByVehicleIdAndStatusAndPickupAt(vehicle.getId(), RentalStatus.RENTED, command.getOnTime())
+//            .orElseThrow(() -> new RuntimeException("렌탈 정보를 찾을 수 없습니다."));
+//        rental.returned(command.getOnTime());
+//        rentalRepository.save(rental);
 
-        final DrivingLogEntity drivingLog = drivingLogRepository.findFirstByRentalIdAndStatus(rental.getId(), DrivingLogStatus.IN_PROGRESS)
-            .orElseThrow(() -> new RuntimeException("운행 일지 정보를 찾을 수 없습니다."));
-
-        drivingLog.completed();
-        drivingLogRepository.save(drivingLog);
-
-        final RouteEntity route = routeRepository.findFirstByDrivingLogIdAndStatusOrderByStartAtDesc(drivingLog.getId(), RouteStatus.ACTIVE)
-            .orElseThrow(() -> new RuntimeException("경로 정보를 찾을 수 없습니다."));
-        route.completed(command.getLat(), command.getLon(), command.getTotalDistance(), command.getOffTime());
-        routeRepository.save(route);
+//        final DrivingLogEntity drivingLog = drivingLogRepository.findFirstByRentalIdAndStatus(rental.getId(), DrivingLogStatus.IN_PROGRESS)
+//            .orElseThrow(() -> new RuntimeException("운행 일지 정보를 찾을 수 없습니다."));
+//
+//        drivingLog.completed();
+//        drivingLogRepository.save(drivingLog);
+//
+//        final RouteEntity route = routeRepository.findFirstByDrivingLogIdAndStatusOrderByStartAtDesc(drivingLog.getId(), RouteStatus.ACTIVE)
+//            .orElseThrow(() -> new RuntimeException("경로 정보를 찾을 수 없습니다."));
+//        route.completed(command.getLat(), command.getLon(), command.getTotalDistance(), command.getOffTime());
+//        routeRepository.save(route);
 
         return VehicleCollectorResponse.from(command.getVehicleId());
     }

--- a/collector/src/main/java/kernel360/ckt/collector/application/service/VehicleService.java
+++ b/collector/src/main/java/kernel360/ckt/collector/application/service/VehicleService.java
@@ -1,8 +1,8 @@
-package kernel360.ckt.collector.application;
+package kernel360.ckt.collector.application.service;
 
 import jakarta.persistence.EntityNotFoundException;
+import kernel360.ckt.collector.application.repository.VehicleRepository;
 import kernel360.ckt.core.domain.entity.VehicleEntity;
-import kernel360.ckt.core.repository.VehicleRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 

--- a/collector/src/main/java/kernel360/ckt/collector/application/service/command/VehicleCollectorCycleCommand.java
+++ b/collector/src/main/java/kernel360/ckt/collector/application/service/command/VehicleCollectorCycleCommand.java
@@ -1,4 +1,4 @@
-package kernel360.ckt.collector.application.command;
+package kernel360.ckt.collector.application.service.command;
 
 import kernel360.ckt.core.domain.dto.CycleInformation;
 import lombok.AccessLevel;

--- a/collector/src/main/java/kernel360/ckt/collector/application/service/command/VehicleCollectorOffCommand.java
+++ b/collector/src/main/java/kernel360/ckt/collector/application/service/command/VehicleCollectorOffCommand.java
@@ -1,4 +1,4 @@
-package kernel360.ckt.collector.application.command;
+package kernel360.ckt.collector.application.service.command;
 
 import lombok.AccessLevel;
 import lombok.Getter;

--- a/collector/src/main/java/kernel360/ckt/collector/application/service/command/VehicleCollectorOnCommand.java
+++ b/collector/src/main/java/kernel360/ckt/collector/application/service/command/VehicleCollectorOnCommand.java
@@ -1,4 +1,4 @@
-package kernel360.ckt.collector.application.command;
+package kernel360.ckt.collector.application.service.command;
 
 import java.time.LocalDateTime;
 import kernel360.ckt.core.domain.entity.DrivingLogEntity;

--- a/collector/src/main/java/kernel360/ckt/collector/application/service/command/VehicleCollectorOnCommand.java
+++ b/collector/src/main/java/kernel360/ckt/collector/application/service/command/VehicleCollectorOnCommand.java
@@ -34,7 +34,7 @@ public class VehicleCollectorOnCommand {
         return new VehicleCollectorOnCommand(vehicleId, gcd, lat, lon, direction, speed, totalDistance, onTime);
     }
 
-    public DrivingLogEntity toDrivingLogentity(RentalEntity rental, VehicleEntity vehicle) {
+    public DrivingLogEntity toDrivingLogEntity(RentalEntity rental, VehicleEntity vehicle) {
         return DrivingLogEntity.create(rental, vehicle);
     }
 

--- a/collector/src/main/java/kernel360/ckt/collector/common/exception/GlobalExceptionHandler.java
+++ b/collector/src/main/java/kernel360/ckt/collector/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,24 @@
+package kernel360.ckt.collector.common.exception;
+
+import kernel360.ckt.core.common.error.ErrorCode;
+import kernel360.ckt.core.common.exception.CustomException;
+import kernel360.ckt.core.common.response.ErrorResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(CustomException.class)
+    public ResponseEntity<ErrorResponse> handleCustomException(CustomException ex) {
+        ErrorCode errorCode = ex.getErrorCode();
+        return ResponseEntity.ok(ErrorResponse.from(errorCode));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleGeneralException(Exception ex) {
+        return ResponseEntity.ok(ErrorResponse.from(HttpStatus.INTERNAL_SERVER_ERROR.value(), ex.getMessage()));
+    }
+}

--- a/collector/src/main/java/kernel360/ckt/collector/infra/repository/jpa/DrivingLogJpaRepository.java
+++ b/collector/src/main/java/kernel360/ckt/collector/infra/repository/jpa/DrivingLogJpaRepository.java
@@ -1,7 +1,7 @@
 package kernel360.ckt.collector.infra.repository.jpa;
 
+import kernel360.ckt.collector.application.repository.DrivingLogRepository;
 import kernel360.ckt.core.domain.entity.DrivingLogEntity;
-import kernel360.ckt.core.repository.DrivingLogRepository;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface DrivingLogJpaRepository extends JpaRepository<DrivingLogEntity, Long>, DrivingLogRepository {

--- a/collector/src/main/java/kernel360/ckt/collector/infra/repository/jpa/RentalJpaRepository.java
+++ b/collector/src/main/java/kernel360/ckt/collector/infra/repository/jpa/RentalJpaRepository.java
@@ -1,7 +1,7 @@
 package kernel360.ckt.collector.infra.repository.jpa;
 
+import kernel360.ckt.collector.application.repository.RentalRepository;
 import kernel360.ckt.core.domain.entity.RentalEntity;
-import kernel360.ckt.core.repository.RentalRepository;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface RentalJpaRepository extends JpaRepository<RentalEntity, Long>, RentalRepository {

--- a/collector/src/main/java/kernel360/ckt/collector/infra/repository/jpa/RentalJpaRepository.java
+++ b/collector/src/main/java/kernel360/ckt/collector/infra/repository/jpa/RentalJpaRepository.java
@@ -1,8 +1,28 @@
 package kernel360.ckt.collector.infra.repository.jpa;
 
+import java.time.LocalDateTime;
+import java.util.Optional;
 import kernel360.ckt.collector.application.repository.RentalRepository;
 import kernel360.ckt.core.domain.entity.RentalEntity;
+import kernel360.ckt.core.domain.enums.RentalStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface RentalJpaRepository extends JpaRepository<RentalEntity, Long>, RentalRepository {
+    @Query("""
+        SELECT r FROM RentalEntity r
+        JOIN FETCH r.vehicle v
+        JOIN FETCH r.company co
+        JOIN FETCH r.customer c
+        WHERE r.vehicle.id = :vehicleId
+          AND r.pickupAt <= :onTime
+          AND r.returnAt >= :onTime
+          AND r.status = :status
+    """)
+    Optional<RentalEntity> findActiveRental(
+        @Param("vehicleId") Long vehicleId,
+        @Param("onTime") LocalDateTime onTime,
+        @Param("status") RentalStatus status
+    );
 }

--- a/collector/src/main/java/kernel360/ckt/collector/infra/repository/jpa/RouteJpaRepository.java
+++ b/collector/src/main/java/kernel360/ckt/collector/infra/repository/jpa/RouteJpaRepository.java
@@ -1,7 +1,7 @@
 package kernel360.ckt.collector.infra.repository.jpa;
 
+import kernel360.ckt.collector.application.repository.RouteRepository;
 import kernel360.ckt.core.domain.entity.RouteEntity;
-import kernel360.ckt.core.repository.RouteRepository;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface RouteJpaRepository extends JpaRepository<RouteEntity, Long>, RouteRepository {

--- a/collector/src/main/java/kernel360/ckt/collector/infra/repository/jpa/VehicleJpaRepository.java
+++ b/collector/src/main/java/kernel360/ckt/collector/infra/repository/jpa/VehicleJpaRepository.java
@@ -1,8 +1,8 @@
 package kernel360.ckt.collector.infra.repository.jpa;
 
+import kernel360.ckt.collector.application.repository.VehicleRepository;
 import kernel360.ckt.core.domain.entity.VehicleEntity;
 import kernel360.ckt.core.domain.enums.VehicleStatus;
-import kernel360.ckt.core.repository.VehicleRepository;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;

--- a/collector/src/main/java/kernel360/ckt/collector/infra/repository/jpa/VehicleTraceLogJpaRepository.java
+++ b/collector/src/main/java/kernel360/ckt/collector/infra/repository/jpa/VehicleTraceLogJpaRepository.java
@@ -1,8 +1,9 @@
 package kernel360.ckt.collector.infra.repository.jpa;
 
+import kernel360.ckt.collector.application.repository.VehicleTraceLogRepository;
 import kernel360.ckt.core.domain.entity.VehicleTraceLogEntity;
-import kernel360.ckt.core.repository.VehicleTraceLogRepository;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface VehicleTraceLogJpaRepository extends JpaRepository<VehicleTraceLogEntity, Long>, VehicleTraceLogRepository {
+public interface VehicleTraceLogJpaRepository extends JpaRepository<VehicleTraceLogEntity, Long>,
+    VehicleTraceLogRepository {
 }

--- a/collector/src/main/java/kernel360/ckt/collector/ui/VehicleCollectorController.java
+++ b/collector/src/main/java/kernel360/ckt/collector/ui/VehicleCollectorController.java
@@ -1,9 +1,9 @@
 package kernel360.ckt.collector.ui;
 
-import kernel360.ckt.collector.application.VehicleCollectorService;
-import kernel360.ckt.collector.application.command.VehicleCollectorCycleCommand;
-import kernel360.ckt.collector.application.command.VehicleCollectorOffCommand;
-import kernel360.ckt.collector.application.command.VehicleCollectorOnCommand;
+import kernel360.ckt.collector.application.service.VehicleCollectorService;
+import kernel360.ckt.collector.application.service.command.VehicleCollectorCycleCommand;
+import kernel360.ckt.collector.application.service.command.VehicleCollectorOffCommand;
+import kernel360.ckt.collector.application.service.command.VehicleCollectorOnCommand;
 import kernel360.ckt.collector.ui.dto.request.VehicleCollectorCycleRequest;
 import kernel360.ckt.collector.ui.dto.request.VehicleCollectorOffRequest;
 import kernel360.ckt.collector.ui.dto.request.VehicleCollectorOnRequest;

--- a/collector/src/main/java/kernel360/ckt/collector/ui/dto/request/VehicleCollectorCycleRequest.java
+++ b/collector/src/main/java/kernel360/ckt/collector/ui/dto/request/VehicleCollectorCycleRequest.java
@@ -1,6 +1,6 @@
 package kernel360.ckt.collector.ui.dto.request;
 
-import kernel360.ckt.collector.application.command.VehicleCollectorCycleCommand;
+import kernel360.ckt.collector.application.service.command.VehicleCollectorCycleCommand;
 import kernel360.ckt.core.domain.dto.CycleInformation;
 
 import java.time.LocalDateTime;

--- a/collector/src/main/java/kernel360/ckt/collector/ui/dto/request/VehicleCollectorOffRequest.java
+++ b/collector/src/main/java/kernel360/ckt/collector/ui/dto/request/VehicleCollectorOffRequest.java
@@ -1,6 +1,6 @@
 package kernel360.ckt.collector.ui.dto.request;
 
-import kernel360.ckt.collector.application.command.VehicleCollectorOffCommand;
+import kernel360.ckt.collector.application.service.command.VehicleCollectorOffCommand;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;

--- a/collector/src/main/java/kernel360/ckt/collector/ui/dto/request/VehicleCollectorOnRequest.java
+++ b/collector/src/main/java/kernel360/ckt/collector/ui/dto/request/VehicleCollectorOnRequest.java
@@ -1,6 +1,6 @@
 package kernel360.ckt.collector.ui.dto.request;
 
-import kernel360.ckt.collector.application.command.VehicleCollectorOnCommand;
+import kernel360.ckt.collector.application.service.command.VehicleCollectorOnCommand;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;

--- a/core/src/main/java/kernel360/ckt/core/domain/entity/DrivingLogEntity.java
+++ b/core/src/main/java/kernel360/ckt/core/domain/entity/DrivingLogEntity.java
@@ -1,18 +1,28 @@
 package kernel360.ckt.core.domain.entity;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.Lob;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
 import kernel360.ckt.core.domain.enums.DrivingLogStatus;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDateTime;
-
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "driving_log")
 @Entity
-public class DrivingLogEntity {
+public class DrivingLogEntity extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -33,17 +43,10 @@ public class DrivingLogEntity {
     @Lob
     private String memo;
 
-    @Column
-    private LocalDateTime createAt;
-
-    @Column
-    private LocalDateTime updateAt;
-
     private DrivingLogEntity(RentalEntity rental, VehicleEntity vehicle, DrivingLogStatus status) {
         this.rental = rental;
         this.vehicle = vehicle;
         this.status = status;
-        this.createAt = LocalDateTime.now();
     }
 
     public static DrivingLogEntity create(RentalEntity rental, VehicleEntity vehicle) {
@@ -56,6 +59,5 @@ public class DrivingLogEntity {
 
     public void completed() {
         this.status = DrivingLogStatus.COMPLETED;
-        this.updateAt = LocalDateTime.now();
     }
 }

--- a/core/src/main/java/kernel360/ckt/core/domain/entity/RentalEntity.java
+++ b/core/src/main/java/kernel360/ckt/core/domain/entity/RentalEntity.java
@@ -49,12 +49,15 @@ public class RentalEntity extends BaseTimeEntity {
     }
 
     public static RentalEntity create(CompanyEntity company, VehicleEntity vehicle, CustomerEntity customer, LocalDateTime pickupAt, LocalDateTime returnAt) {
-        return new RentalEntity(company, vehicle, customer, pickupAt, returnAt, RentalStatus.RENTED);
+        return new RentalEntity(company, vehicle, customer, pickupAt, returnAt, RentalStatus.PENDING);
     }
 
-    public void returned(LocalDateTime returnAt) {
-        this.status = RentalStatus.RENTED;
-        this.returnAt = returnAt;
+    public void changeStatus(RentalStatus status) {
+        this.status.update(this, status);
+    }
+
+    public void updateStatus(RentalStatus status) {
+        this.status = status;
     }
 
 }

--- a/core/src/main/java/kernel360/ckt/core/domain/entity/RentalEntity.java
+++ b/core/src/main/java/kernel360/ckt/core/domain/entity/RentalEntity.java
@@ -39,17 +39,21 @@ public class RentalEntity extends BaseTimeEntity {
     @Column
     private LocalDateTime returnAt;
 
-    private RentalEntity(CompanyEntity company, VehicleEntity vehicle, CustomerEntity customer, LocalDateTime pickupAt, LocalDateTime returnAt, RentalStatus status) {
+    @Lob
+    private String memo;
+
+    private RentalEntity(CompanyEntity company, VehicleEntity vehicle, CustomerEntity customer, LocalDateTime pickupAt, LocalDateTime returnAt, RentalStatus status, String memo) {
         this.company = company;
         this.vehicle = vehicle;
         this.customer = customer;
         this.status = status;
         this.pickupAt = pickupAt;
         this.returnAt = returnAt;
+        this.memo = memo;
     }
 
-    public static RentalEntity create(CompanyEntity company, VehicleEntity vehicle, CustomerEntity customer, LocalDateTime pickupAt, LocalDateTime returnAt) {
-        return new RentalEntity(company, vehicle, customer, pickupAt, returnAt, RentalStatus.PENDING);
+    public static RentalEntity create(CompanyEntity company, VehicleEntity vehicle, CustomerEntity customer, LocalDateTime pickupAt, LocalDateTime returnAt, String memo) {
+        return new RentalEntity(company, vehicle, customer, pickupAt, returnAt, RentalStatus.PENDING, memo);
     }
 
     public void changeStatus(RentalStatus status) {

--- a/core/src/main/java/kernel360/ckt/core/domain/entity/RentalEntity.java
+++ b/core/src/main/java/kernel360/ckt/core/domain/entity/RentalEntity.java
@@ -11,7 +11,7 @@ import java.time.LocalDateTime;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "rental")
 @Entity
-public class RentalEntity {
+public class RentalEntity extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -26,7 +26,7 @@ public class RentalEntity {
     private VehicleEntity vehicle;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "customer_id")
+    @JoinColumn(name = "customer_id", nullable = false)
     private CustomerEntity customer;
 
     @Enumerated(EnumType.STRING)
@@ -39,21 +39,17 @@ public class RentalEntity {
     @Column
     private LocalDateTime returnAt;
 
-    @Column
-    private LocalDateTime createAt;
-
-    @Column
-    private LocalDateTime updateAt;
-
-    private RentalEntity(VehicleEntity vehicle, LocalDateTime pickupAt, RentalStatus status) {
+    private RentalEntity(CompanyEntity company, VehicleEntity vehicle, CustomerEntity customer, LocalDateTime pickupAt, LocalDateTime returnAt, RentalStatus status) {
+        this.company = company;
         this.vehicle = vehicle;
+        this.customer = customer;
         this.status = status;
         this.pickupAt = pickupAt;
-        this.createAt = LocalDateTime.now();
+        this.returnAt = returnAt;
     }
 
-    public static RentalEntity create(VehicleEntity vehicle, LocalDateTime pickupAt) {
-        return new RentalEntity(vehicle, pickupAt, RentalStatus.RENTED);
+    public static RentalEntity create(CompanyEntity company, VehicleEntity vehicle, CustomerEntity customer, LocalDateTime pickupAt, LocalDateTime returnAt) {
+        return new RentalEntity(company, vehicle, customer, pickupAt, returnAt, RentalStatus.RENTED);
     }
 
     public void returned(LocalDateTime returnAt) {

--- a/core/src/main/java/kernel360/ckt/core/domain/entity/RouteEntity.java
+++ b/core/src/main/java/kernel360/ckt/core/domain/entity/RouteEntity.java
@@ -19,7 +19,7 @@ public class RouteEntity {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "driving_log_id", unique = true)
+    @JoinColumn(name = "driving_log_id")
     private DrivingLogEntity drivingLog;
 
     @Enumerated(EnumType.STRING)

--- a/core/src/main/java/kernel360/ckt/core/domain/enums/RentalStatus.java
+++ b/core/src/main/java/kernel360/ckt/core/domain/enums/RentalStatus.java
@@ -1,14 +1,42 @@
 package kernel360.ckt.core.domain.enums;
 
+import kernel360.ckt.core.domain.entity.RentalEntity;
 import lombok.Getter;
 
 @Getter
 public enum RentalStatus {
-    PENDING("대기 중"),
-    RENTED("대여 중"),
-    RETURNED("반납 완료"),
-    CANCEL("대여 취소")
-    ;
+    PENDING("예약 대기") {
+        @Override
+        public void update(RentalEntity rental, RentalStatus newStatus) {
+            if (newStatus == RENTED || newStatus == CANCELED) {
+                rental.updateStatus(newStatus);
+            } else {
+                throw new IllegalStateException(newStatus.getValue() + " 상태로 변경할 수 없습니다.");
+            }
+        }
+    },
+    RENTED("렌트 중") {
+        @Override
+        public void update(RentalEntity rental, RentalStatus newStatus) {
+            if (newStatus == RETURNED) {
+                rental.updateStatus(newStatus);
+            } else {
+                throw new IllegalStateException(newStatus.getValue() + " 상태로 변경할 수 없습니다.");
+            }
+        }
+    },
+    RETURNED("반납 완료") {
+        @Override
+        public void update(RentalEntity rental, RentalStatus newStatus) {
+            throw new IllegalStateException("반납 완료된 상태는 변경할 수 없습니다.");
+        }
+    },
+    CANCELED("렌트 취소") {
+        @Override
+        public void update(RentalEntity rental, RentalStatus newStatus) {
+            throw new IllegalStateException("취소된 상태는 변경할 수 없습니다.");
+        }
+    };
 
     private final String value;
 
@@ -16,4 +44,5 @@ public enum RentalStatus {
         this.value = value;
     }
 
+    public abstract void update(RentalEntity rental, RentalStatus newStatus);
 }

--- a/core/src/main/java/kernel360/ckt/core/domain/enums/RentalStatus.java
+++ b/core/src/main/java/kernel360/ckt/core/domain/enums/RentalStatus.java
@@ -6,7 +6,8 @@ import lombok.Getter;
 public enum RentalStatus {
     PENDING("대기 중"),
     RENTED("대여 중"),
-    RETURNED("반납 완료")
+    RETURNED("반납 완료"),
+    CANCEL("대여 취소")
     ;
 
     private final String value;

--- a/core/src/main/java/kernel360/ckt/core/domain/enums/RentalStatus.java
+++ b/core/src/main/java/kernel360/ckt/core/domain/enums/RentalStatus.java
@@ -15,7 +15,7 @@ public enum RentalStatus {
             }
         }
     },
-    RENTED("렌트 중") {
+    RENTED("예약 중") {
         @Override
         public void update(RentalEntity rental, RentalStatus newStatus) {
             if (newStatus == RETURNED) {
@@ -31,7 +31,7 @@ public enum RentalStatus {
             throw new IllegalStateException("반납 완료된 상태는 변경할 수 없습니다.");
         }
     },
-    CANCELED("렌트 취소") {
+    CANCELED("예약 취소") {
         @Override
         public void update(RentalEntity rental, RentalStatus newStatus) {
             throw new IllegalStateException("취소된 상태는 변경할 수 없습니다.");

--- a/core/src/main/java/kernel360/ckt/core/repository/DrivingLogRepository.java
+++ b/core/src/main/java/kernel360/ckt/core/repository/DrivingLogRepository.java
@@ -1,6 +1,7 @@
 package kernel360.ckt.core.repository;
 
 import kernel360.ckt.core.domain.entity.DrivingLogEntity;
+import kernel360.ckt.core.domain.entity.RentalEntity;
 import kernel360.ckt.core.domain.enums.DrivingLogStatus;
 
 import java.util.Optional;
@@ -8,6 +9,8 @@ import java.util.Optional;
 public interface DrivingLogRepository {
     DrivingLogEntity save(DrivingLogEntity drivingLog);
 
-    Optional<DrivingLogEntity> findFirstByVehicleIdAndStatusOrderByCreateAtDesc(Long vehicleId, DrivingLogStatus status);
+    Optional<DrivingLogEntity> findByRental(RentalEntity rental);
+
+    Optional<DrivingLogEntity> findFirstByVehicleIdAndStatusOrderByCreatedAtDesc(Long vehicleId, DrivingLogStatus status);
     Optional<DrivingLogEntity> findFirstByRentalIdAndStatus(Long rentalId, DrivingLogStatus status);
 }

--- a/core/src/main/java/kernel360/ckt/core/repository/RentalRepository.java
+++ b/core/src/main/java/kernel360/ckt/core/repository/RentalRepository.java
@@ -1,12 +1,35 @@
 package kernel360.ckt.core.repository;
 
-import kernel360.ckt.core.domain.entity.RentalEntity;
-import kernel360.ckt.core.domain.enums.RentalStatus;
-
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
+import kernel360.ckt.core.domain.entity.RentalEntity;
+import kernel360.ckt.core.domain.entity.VehicleEntity;
+import kernel360.ckt.core.domain.enums.RentalStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 public interface RentalRepository {
     RentalEntity save(RentalEntity rental);
+
+    List<RentalEntity> findOverlappingRentalsByVehicleAndStatuses(
+        VehicleEntity vehicle,
+        List<RentalStatus> statuses,
+        LocalDateTime pickupAt,
+        LocalDateTime returnAt
+    );
+
+    Page<RentalEntity> search(
+        Long companyId,
+        RentalStatus status,
+        String keyword,
+        LocalDateTime startAt,
+        LocalDateTime endAt,
+        Pageable pageable
+    );
+
+    Optional<RentalEntity> findById(Long id);
+
     Optional<RentalEntity> findFirstByVehicleIdAndStatusAndPickupAt(Long vehicleId, RentalStatus status, LocalDateTime pickupAt);
+
 }

--- a/core/src/main/java/kernel360/ckt/core/repository/RouteRepository.java
+++ b/core/src/main/java/kernel360/ckt/core/repository/RouteRepository.java
@@ -7,5 +7,5 @@ import java.util.Optional;
 
 public interface RouteRepository {
     RouteEntity save(RouteEntity route);
-    Optional<RouteEntity> findFirstByDrivingLogIdAndStatusOrderByStartAtDesc(Long drivingLogId, RouteStatus routeStatus);
+    Optional<RouteEntity> findFirstByDrivingLogAndStatusOrderByStartAtDesc(Long drivingLogId, RouteStatus routeStatus);
 }

--- a/gateway/src/main/java/kernel360/ckt/gateway/config/GatewayConfig.java
+++ b/gateway/src/main/java/kernel360/ckt/gateway/config/GatewayConfig.java
@@ -25,6 +25,9 @@ public class GatewayConfig {
     @Value("${backend.admin-url}")
     private String adminUrl;
 
+    @Value("${backend.collector-url}")
+    private String collectorUrl;
+
     @Value("${backend.frontend-origin}")
     private String frontendOrigin;
 
@@ -34,6 +37,9 @@ public class GatewayConfig {
 
             .route("auth", r -> r.path("/api/v1/auth/**")
                 .uri(authUrl))
+
+            .route("collector", r -> r.path("/api/v1/vehicles/collector/**")
+                .uri(collectorUrl))
 
             .route("admin", r -> r.path("/api/v1/companies/**")
                 .uri(adminUrl))

--- a/gateway/src/main/java/kernel360/ckt/gateway/config/GatewayConfig.java
+++ b/gateway/src/main/java/kernel360/ckt/gateway/config/GatewayConfig.java
@@ -44,6 +44,9 @@ public class GatewayConfig {
             .route("vehicle", r -> r.path("/api/v1/vehicles/**")
                 .uri(adminUrl))
 
+            .route("rental", r -> r.path("/api/v1/rentals/**")
+                .uri(adminUrl))
+
             .build();
     }
     @Bean

--- a/gateway/src/main/resources/application-docker.yml
+++ b/gateway/src/main/resources/application-docker.yml
@@ -22,6 +22,10 @@ spring:
             uri: http://admin:8080
             predicates:
               - Path=/api/v1/logs/**
+          - id: collector
+            uri: http://collector:8000
+            predicates:
+              - Path=/api/v1/vehicles/collector/**
 
 backend:
   frontend-origin: http://localhost:5173

--- a/gateway/src/main/resources/application-local.yml
+++ b/gateway/src/main/resources/application-local.yml
@@ -1,4 +1,5 @@
 backend:
   auth-url: http://localhost:8082
   admin-url: http://localhost:8080
+  collector-url: http://localhost:8090
   frontend-origin: http://localhost:5173

--- a/gateway/src/main/resources/application.yml
+++ b/gateway/src/main/resources/application.yml
@@ -16,4 +16,4 @@ spring:
 
 jwt:
   secret: ${JWT_SECRET}
-  whitelist: "/api/v1/auth/login,/api/v1/auth/join,/api/v1/auth/password-reset"
+  whitelist: "/api/v1/auth/login,/api/v1/auth/join,/api/v1/auth/password-reset,/api/v1/vehicles/collector/on,/api/v1/vehicles/collector/off,/api/v1/vehicles/collector/cycle"


### PR DESCRIPTION
## #️⃣ 연관된 이슈
<!-- ex) #이슈번호[, #이슈번호] -->

> #35 


## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 설명해 주세요. (이미지 첨부 가능) -->

> 차량 관제 데이터 및 예약 관리 분리 작업
> - 기존 차량 관제(Collector) 시스템의 ON 요청 처리 로직에 통합되어 있던 차량 예약(Rental) 생성 기능을 분리하고, 별도의 예약 관리 페이지 및 관련 API를 추가하였습니다.
> 예약 관리 목록 조회
> 예약 관리 상세 조회
> 예약 관리 등록
> 예약 관리 상태 변경
> collector 모듈 core repository 의존 제거
> collector 모듈 gateway config 설정


## 👀 리뷰어 가이드라인
<!-- 리뷰어가 중점적으로 확인해야 할 사항을 작성해 주세요. -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

> 예약 API 호출시 company id 는 로그인한 업체의 id를 가져오도록 설정하였습니다.
> 저희 core 의 repository 선언되어 참조되어 있는 부분 각 module 로 내리기로 하였는데, 현재 collector 는 작업자가 따로 없는 것 같아서 작업 진행했습니다. core 의 repository 는 혹시 참조하시는 분이 있으실까봐 제거하진 않았습니다. 이 부분은 1차 배포 이후에 한번에 작업해서 내리면 좋을 것 같습니다
> collector service 변경 사항 확인 부탁드립니다.
> - 기존 on off 시 예약 테이블 도 생성하였는데, 예약 관리를 추가하면서 분리하였습니다.
> - 현재, 예약한 차량만 애뮬레이터 시동을 on 할 수 있도록 제약 조건을 추가해놨습니다.
> - 프로세스는 다음과 같습니다.
>   - 예약 등록 (상태 : 대기중) -> 예약 상태 변경 (대여중) -> 애뮬레이터 시동 ON / OFF (반복시 경로 테이블 생성) -> 예약 상태 변경 (반납) 
> - 예약 상태 변경에 제약 조건이 추가되어 있습니다.
>   - 대기중 : 대여중 및 취소 가능
>   - 대여중 : 반납 가능
>   - 반납 및 취소 : 상태 변경 불가능
>

