### PR TITLE
feat: admin/auth 모듈에 글로벌 예외 처리기 및 요청 바디 캐싱 필터 추가

### DIFF
--- a/admin/src/main/java/kernel360/ckt/admin/common/exception/GlobalExceptionHandler.java
+++ b/admin/src/main/java/kernel360/ckt/admin/common/exception/GlobalExceptionHandler.java
@@ -1,39 +1,62 @@
 package kernel360.ckt.admin.common.exception;
 
+import jakarta.servlet.http.HttpServletRequest;
 import kernel360.ckt.core.common.exception.CustomException;
 import kernel360.ckt.core.common.error.ErrorCode;
 import kernel360.ckt.core.common.response.ErrorResponse;
+import kernel360.ckt.core.common.util.MaskingUtil;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
-
+import org.springframework.web.util.ContentCachingRequestWrapper;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.stream.Collectors;
 
+
+@Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
     @ExceptionHandler(CustomException.class)
-    public ResponseEntity<ErrorResponse> handleCustomException(CustomException ex) {
+    public ResponseEntity<ErrorResponse> handleCustomException(CustomException ex, HttpServletRequest request) {
+        String method = request.getMethod();
+        String uri = request.getRequestURI();
+        String params = getRequestParams(request);
+        log.error("⛔️ - URI: {} {}\n- Params: {}\nCustomException: {}",
+            method, uri, params, ex.getErrorCode().getMessage());
         ErrorCode errorCode = ex.getErrorCode();
         return ResponseEntity.ok(ErrorResponse.from(errorCode));
     }
 
-    //Validation 실패 처리 (@Valid)
-    @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ResponseEntity<ErrorResponse> handleValidationException(MethodArgumentNotValidException ex) {
-        String errorMessages = ex.getBindingResult()
-            .getFieldErrors()
-            .stream()
-            .map(error -> error.getField() + ": " + error.getDefaultMessage())
-            .collect(Collectors.joining(", "));
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleGeneralException(Exception ex, HttpServletRequest request) {
+        String method = request.getMethod();
+        String uri = request.getRequestURI();
+        String params = getRequestParams(request);
 
-        return ResponseEntity.ok(ErrorResponse.from(HttpStatus.BAD_REQUEST.value(), errorMessages));
+        String body = null;
+        if (request instanceof ContentCachingRequestWrapper wrapper) {
+            byte[] buf = wrapper.getContentAsByteArray();
+            if (buf.length > 0) {
+                body = new String(buf, StandardCharsets.UTF_8);
+                body = MaskingUtil.maskJsonBody(body);
+            }
+        }
+
+        log.error("⛔️ - URI: {} {}\n- Params: {}\n- Body: {}\nGeneralException 발생",
+            method, uri, params, body, ex);
+
+        return ResponseEntity.ok(
+            ErrorResponse.from(HttpStatus.INTERNAL_SERVER_ERROR.value(), ex.getMessage())
+        );
     }
 
-    @ExceptionHandler(Exception.class)
-    public ResponseEntity<ErrorResponse> handleGeneralException(Exception ex) {
-        return ResponseEntity.ok(ErrorResponse.from(HttpStatus.INTERNAL_SERVER_ERROR.value(), ex.getMessage()));
+    private String getRequestParams(HttpServletRequest request) {
+        return request.getParameterMap().entrySet().stream()
+            .map(entry -> entry.getKey() + "=" + Arrays.toString(entry.getValue()))
+            .collect(Collectors.joining(", "));
     }
 }

--- a/auth/src/main/java/kernel360/ckt/auth/common/exception/GlobalExceptionHandler.java
+++ b/auth/src/main/java/kernel360/ckt/auth/common/exception/GlobalExceptionHandler.java
@@ -1,37 +1,89 @@
 package kernel360.ckt.auth.common.exception;
 
-import kernel360.ckt.core.common.error.ErrorCode;
+import jakarta.servlet.http.HttpServletRequest;
 import kernel360.ckt.core.common.exception.CustomException;
 import kernel360.ckt.core.common.response.ErrorResponse;
+import kernel360.ckt.core.common.util.MaskingUtil;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.util.ContentCachingRequestWrapper;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.stream.Collectors;
 
 @Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
     @ExceptionHandler(CustomException.class)
-    public ResponseEntity<ErrorResponse> handleCustomException(CustomException ex) {
-        ErrorCode errorCode = ex.getErrorCode();
-        log.error("[CustomException] code={}, message={}", errorCode.getCode(), errorCode.getMessage(), ex);
-        return ResponseEntity.ok(ErrorResponse.from(errorCode));
+    public ResponseEntity<ErrorResponse> handleCustomException(
+        CustomException ex,
+        HttpServletRequest request
+    ) {
+        String method = request.getMethod();
+        String uri    = request.getRequestURI();
+        String params = getRequestParams(request);
+
+        log.error("⛔️ - URI: {} {}\n- Params: {}\nCustomException: {}",
+            method, uri, params, ex.getErrorCode().getMessage(), ex);
+
+        return ResponseEntity.ok(
+            ErrorResponse.from(ex.getErrorCode())
+        );
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ResponseEntity<ErrorResponse> handleValidationExceptions(MethodArgumentNotValidException ex) {
-        log.error("[ValidationException] {}", ex.getMessage(), ex);
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                .body(ErrorResponse.from(400, "요청 파라미터 유효성 검사에 실패했습니다."));
+    public ResponseEntity<ErrorResponse> handleValidationExceptions(
+        MethodArgumentNotValidException ex,
+        HttpServletRequest request
+    ) {
+        String method = request.getMethod();
+        String uri    = request.getRequestURI();
+        String params = getRequestParams(request);
+
+        log.error("⛔️ - URI: {} {}\n- Params: {}\nValidationException: {}",
+            method, uri, params, ex.getMessage(), ex);
+
+        return ResponseEntity
+            .status(HttpStatus.BAD_REQUEST)
+            .body(ErrorResponse.from(400, "요청 파라미터 유효성 검사에 실패했습니다."));
     }
 
     @ExceptionHandler(Exception.class)
-    public ResponseEntity<ErrorResponse> handleGeneralException(Exception ex) {
-        log.error("[UnhandledException] {}", ex.getMessage(), ex);
-        return  ResponseEntity.ok(ErrorResponse.from(HttpStatus.INTERNAL_SERVER_ERROR.value(), ex.getMessage()));
+    public ResponseEntity<ErrorResponse> handleGeneralException(
+        Exception ex,
+        HttpServletRequest request
+    ) {
+        String method = request.getMethod();
+        String uri = request.getRequestURI();
+        String params = getRequestParams(request);
+
+        String body = null;
+        if (request instanceof ContentCachingRequestWrapper wrapper) {
+            byte[] buf = wrapper.getContentAsByteArray();
+            if (buf.length > 0) {
+                body = new String(buf, StandardCharsets.UTF_8);
+                body = MaskingUtil.maskJsonBody(body);
+            }
+        }
+
+        log.error("⛔️ - URI: {} {}\n- Params: {}\n- Body: {}\nGeneralException 발생",
+            method, uri, params, body, ex);
+
+        return ResponseEntity.ok(
+            ErrorResponse.from(HttpStatus.INTERNAL_SERVER_ERROR.value(), ex.getMessage())
+        );
+    }
+
+    private String getRequestParams(HttpServletRequest request) {
+        return request.getParameterMap().entrySet().stream()
+            .map(e -> e.getKey() + "=" + Arrays.toString(e.getValue()))
+            .collect(Collectors.joining(", "));
     }
 
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
<!-- ex) #이슈번호[, #이슈번호] -->

> #63 


## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 설명해 주세요. (이미지 첨부 가능) -->

> 이전에 Gateway 서비스에만 적용하고, Admin/Auth MVC 서비스에서는 빠뜨렸던 global exception handling 보완

## 📝 작업 내용
> - **admin 모듈**에 `GlobalExceptionHandler` 및 `CachingRequestBodyFilter` 등록  
> - **auth 모듈**에도 동일한 전역 예외 처리기와 요청 바디 캐싱 필터 추가  
> - `CustomException` / `Exception` 핸들러에서 HTTP 메서드·URI·쿼리 파라미터·(가능하면)바디를 로깅하도록 수정  
> - `MaskingUtil.maskJsonBody()`로 요청 바디 내 민감정보 마스킹 적용  
> - 이전에 MVC 서비스들에 빠뜨린 부분을 보완

## 👀 리뷰어 가이드라인
> - `GlobalExceptionHandler` 클래스의 메서드 시그니처(`HttpServletRequest` 파라미터 포함) 및 로깅 메시지 템플릿이 올바른지 확인 부탁드립니다.  
> - `ContentCachingRequestWrapper` 필터가 정상 등록되어 요청 바디가 캐싱되는지, 예외 핸들러에서 읽어오는지 검증해 주세요.  
> - Docker 환경에서 컨테이너 로그(`docker-compose logs -f`)로 원하는 예외 로그가 출력되는지 최종 확인해 주세요.