### PR TITLE
feat: 차량 회사별 권한 및 삭제 여부 추가

### DIFF
--- a/admin/src/main/java/kernel360/ckt/admin/application/port/VehicleRepository.java
+++ b/admin/src/main/java/kernel360/ckt/admin/application/port/VehicleRepository.java
@@ -1,7 +1,5 @@
 package kernel360.ckt.admin.application.port;
 
-import jakarta.validation.constraints.FutureOrPresent;
-import jakarta.validation.constraints.NotNull;
 import kernel360.ckt.core.domain.entity.VehicleEntity;
 import kernel360.ckt.core.domain.enums.VehicleStatus;
 import org.springframework.data.domain.Page;
@@ -26,26 +24,27 @@ public interface VehicleRepository {
 
     /**
      * 차량 차량 목록을 페이징하여 조회합니다.
+     * @param companyId 조회할 회사
      * @param status 차량 상태
      * @param keyword 검색 키워드 (차량 번호, 모델명 등)
      * @param pageable 페이징 정보
      * @return 조건에 부합하는 차량 목록 (Page)
      */
-    Page<VehicleEntity> findAll(VehicleStatus status, String keyword, Pageable pageable);
+    Page<VehicleEntity> findAll(Long companyId, VehicleStatus status, String keyword, Pageable pageable);
 
     /**
      * 차량 ID로 차량을 조회합니다.
      * @param vehicleId 차량 ID
      * @return 존재할 경우 차량 엔티티, 존재하지 않을 경우 빈 Optional
      */
-    Optional<VehicleEntity> findById(Long vehicleId);
+    Optional<VehicleEntity> findById(Long vehicleId, Long companyId);
 
     /**
      * 차량 등록 번호로 차량을 조회합니다.
      * @param registrationNumber 차량 등록 번호
      * @return 존재할 경우 차량 엔티티, 존재하지 않을 경우 빈 Optional
      */
-    Optional<VehicleEntity> findByRegistrationNumber(String registrationNumber);
+    Optional<VehicleEntity> findByRegistrationNumber(Long companyId, String registrationNumber);
 
     /**
      * 전체 차량 수를 반환합니다.
@@ -55,9 +54,10 @@ public interface VehicleRepository {
 
     /**
      * 예약가능한 차량을 조회합니다.
+     * @param companyId 조회할 회사
      * @param keyword 차량 번호 or 모델명
      * @param pickupAt 픽업 시간
      * @param returnAt 반납 시간
      */
-    List<VehicleEntity> searchAvailableVehiclesByKeyword(String keyword, LocalDateTime pickupAt, LocalDateTime returnAt);
+    List<VehicleEntity> searchAvailableVehiclesByKeyword(Long companyId, String keyword, LocalDateTime pickupAt, LocalDateTime returnAt);
 }

--- a/admin/src/main/java/kernel360/ckt/admin/application/port/VehicleRepository.java
+++ b/admin/src/main/java/kernel360/ckt/admin/application/port/VehicleRepository.java
@@ -54,12 +54,6 @@ public interface VehicleRepository {
     long count();
 
     /**
-     * 차량 ID로 차량을 삭제합니다.
-     * @param vehicleId 삭제할 차량 ID
-     */
-    void deleteById(Long vehicleId);
-
-    /**
      * 예약가능한 차량을 조회합니다.
      * @param keyword 차량 번호 or 모델명
      * @param pickupAt 픽업 시간

--- a/admin/src/main/java/kernel360/ckt/admin/application/service/RentalService.java
+++ b/admin/src/main/java/kernel360/ckt/admin/application/service/RentalService.java
@@ -51,7 +51,7 @@ public class RentalService {
         final CompanyEntity company = findCompanyById(command.companyId());
         log.info("회사 정보 조회 - 회사 ID : {}", company.getId());
 
-        final VehicleEntity vehicle = findVehicleById(command.vehicleId());
+        final VehicleEntity vehicle = findVehicleById(command.companyId(), command.vehicleId());
         log.info("차량 정보 조회 - 차량 ID : {}", vehicle.getId());
 
         final CustomerEntity customer = findCustomerById(command.customerId());
@@ -135,7 +135,7 @@ public class RentalService {
         }
 
         if (command.vehicleId() != null && !command.vehicleId().equals(rental.getVehicle().getId())) {
-            updatedVehicle = findVehicleById(command.vehicleId());
+            updatedVehicle = findVehicleById(command.companyId(), command.vehicleId());
             log.info("차량 정보 변경 - 차량 ID: {}", updatedVehicle.getId());
             checkedAvailability = true;
         }
@@ -245,12 +245,13 @@ public class RentalService {
     /**
      * 주어진 ID로 차량 정보를 조회합니다.
      *
+     * @param companyId 조회할 회사의 고유 ID
      * @param vehicleId 조회할 차량의 고유 ID
      * @return 조회된 {@link VehicleEntity} 객체
      * @throws CustomException 해당 ID의 차량 정보를 찾을 수 없는 경우 발생
      */
-    private VehicleEntity findVehicleById(Long vehicleId) {
-        return vehicleRepository.findById(vehicleId)
+    private VehicleEntity findVehicleById(Long companyId, Long vehicleId) {
+        return vehicleRepository.findById(companyId, vehicleId)
             .orElseThrow(() -> new CustomException(VehicleErrorCode.VEHICLE_NOT_FOUND, vehicleId));
     }
 

--- a/admin/src/main/java/kernel360/ckt/admin/application/service/VehicleService.java
+++ b/admin/src/main/java/kernel360/ckt/admin/application/service/VehicleService.java
@@ -1,7 +1,6 @@
 package kernel360.ckt.admin.application.service;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import jakarta.persistence.EntityNotFoundException;
 import jakarta.transaction.Transactional;
 import kernel360.ckt.admin.application.service.command.CreateVehicleCommand;
 import kernel360.ckt.admin.application.service.command.VehicleKeywordCommand;
@@ -45,8 +44,8 @@ public class VehicleService {
                 throw new CustomException(VehicleErrorCode.DUPLICATE_REGISTRATION_NUMBER);
             });
 
-        final VehicleEntity vehicle = command.toEntity(); // entity 생성
-        final VehicleEntity savedVehicle = vehicleRepository.save(vehicle); // 저장
+        final VehicleEntity vehicle = command.toEntity();
+        final VehicleEntity savedVehicle = vehicleRepository.save(vehicle);
 
         log.info("차량 등록 완료 - ID: {}", savedVehicle.getId());
         return savedVehicle;
@@ -103,8 +102,11 @@ public class VehicleService {
 
     public void delete(Long vehicleId) {
         log.info("차량 삭제 시도 - vehicleId: {}", vehicleId);
-        findById(vehicleId);
-        vehicleRepository.deleteById(vehicleId);
+        final VehicleEntity vehicle = findById(vehicleId);
+
+        vehicle.delete();
+        vehicleRepository.save(vehicle);
+
         log.info("차량 삭제 성공 - vehicleId: {}", vehicleId);
     }
 

--- a/admin/src/main/java/kernel360/ckt/admin/application/service/command/CreateVehicleCommand.java
+++ b/admin/src/main/java/kernel360/ckt/admin/application/service/command/CreateVehicleCommand.java
@@ -1,5 +1,6 @@
 package kernel360.ckt.admin.application.service.command;
 
+import kernel360.ckt.core.domain.entity.CompanyEntity;
 import kernel360.ckt.core.domain.entity.VehicleEntity;
 import kernel360.ckt.core.domain.enums.FuelType;
 import kernel360.ckt.core.domain.enums.TransmissionType;
@@ -10,6 +11,7 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public class CreateVehicleCommand {
+    private final Long companyId;
     private final String registrationNumber;
     private final String modelYear;
     private final String manufacturer;
@@ -20,8 +22,9 @@ public class CreateVehicleCommand {
     private final VehicleStatus status;
     private final String memo;
 
-    public VehicleEntity toEntity() {
+    public VehicleEntity toEntity(CompanyEntity company) {
         return VehicleEntity.create(
+            company,
             this.registrationNumber,
             this.modelYear,
             this.manufacturer,

--- a/admin/src/main/java/kernel360/ckt/admin/application/service/command/UpdateVehicleCommand.java
+++ b/admin/src/main/java/kernel360/ckt/admin/application/service/command/UpdateVehicleCommand.java
@@ -9,6 +9,7 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public class UpdateVehicleCommand {
+    private final Long companyId;
     private final String modelYear;
     private final String manufacturer;
     private final String modelName;

--- a/admin/src/main/java/kernel360/ckt/admin/application/service/command/VehicleKeywordCommand.java
+++ b/admin/src/main/java/kernel360/ckt/admin/application/service/command/VehicleKeywordCommand.java
@@ -8,6 +8,7 @@ import java.time.LocalDateTime;
 @Getter
 @RequiredArgsConstructor
 public class VehicleKeywordCommand {
+    private final Long companyId;
     private final String keyword;
     private final LocalDateTime pickupAt;
     private final LocalDateTime returnAt;

--- a/admin/src/main/java/kernel360/ckt/admin/infra/VehicleRepositoryAdapter.java
+++ b/admin/src/main/java/kernel360/ckt/admin/infra/VehicleRepositoryAdapter.java
@@ -30,22 +30,17 @@ public class VehicleRepositoryAdapter implements VehicleRepository {
 
     @Override
     public Optional<VehicleEntity> findById(Long vehicleId) {
-        return vehicleJpaRepository.findById(vehicleId);
+        return vehicleJpaRepository.findByIdAndDeleteYnFalse(vehicleId);
     }
 
     @Override
     public Optional<VehicleEntity> findByRegistrationNumber(String registrationNumber) {
-        return vehicleJpaRepository.findByRegistrationNumber(registrationNumber);
+        return vehicleJpaRepository.findByRegistrationNumberAndDeleteYnFalse(registrationNumber);
     }
 
     @Override
     public long count() {
         return vehicleJpaRepository.count();
-    }
-
-    @Override
-    public void deleteById(Long vehicleId) {
-        vehicleJpaRepository.deleteById(vehicleId);
     }
 
     @Override

--- a/admin/src/main/java/kernel360/ckt/admin/infra/VehicleRepositoryAdapter.java
+++ b/admin/src/main/java/kernel360/ckt/admin/infra/VehicleRepositoryAdapter.java
@@ -24,18 +24,18 @@ public class VehicleRepositoryAdapter implements VehicleRepository {
     }
 
     @Override
-    public Page<VehicleEntity> findAll(VehicleStatus status, String keyword, Pageable pageable) {
-        return vehicleJpaRepository.findAll(status, keyword, pageable);
+    public Page<VehicleEntity> findAll(Long companyId, VehicleStatus status, String keyword, Pageable pageable) {
+        return vehicleJpaRepository.findAll(companyId, status, keyword, pageable);
     }
 
     @Override
-    public Optional<VehicleEntity> findById(Long vehicleId) {
-        return vehicleJpaRepository.findByIdAndDeleteYnFalse(vehicleId);
+    public Optional<VehicleEntity> findById(Long vehicleId, Long companyId) {
+        return vehicleJpaRepository.findByIdAndCompanyIdAndDeleteYnFalse(vehicleId, companyId);
     }
 
     @Override
-    public Optional<VehicleEntity> findByRegistrationNumber(String registrationNumber) {
-        return vehicleJpaRepository.findByRegistrationNumberAndDeleteYnFalse(registrationNumber);
+    public Optional<VehicleEntity> findByRegistrationNumber(Long companyId, String registrationNumber) {
+        return vehicleJpaRepository.findByCompanyIdAndRegistrationNumberAndDeleteYnFalse(companyId, registrationNumber);
     }
 
     @Override
@@ -44,7 +44,7 @@ public class VehicleRepositoryAdapter implements VehicleRepository {
     }
 
     @Override
-    public List<VehicleEntity> searchAvailableVehiclesByKeyword(String keyword, LocalDateTime pickupAt, LocalDateTime returnAt) {
-        return vehicleJpaRepository.searchAvailableVehiclesByKeyword(keyword, pickupAt, returnAt);
+    public List<VehicleEntity> searchAvailableVehiclesByKeyword(Long companyId, String keyword, LocalDateTime pickupAt, LocalDateTime returnAt) {
+        return vehicleJpaRepository.searchAvailableVehiclesByKeyword(companyId, keyword, pickupAt, returnAt);
     }
 }

--- a/admin/src/main/java/kernel360/ckt/admin/infra/jpa/VehicleJpaRepository.java
+++ b/admin/src/main/java/kernel360/ckt/admin/infra/jpa/VehicleJpaRepository.java
@@ -19,6 +19,7 @@ public interface VehicleJpaRepository extends JpaRepository<VehicleEntity, Long>
         AND (v.company.id = :companyId)
         AND (:status IS NULL OR v.status = :status)
         AND (:keyword IS NULL OR v.registrationNumber LIKE %:keyword% OR v.modelName LIKE %:keyword%)
+        ORDER BY v.createdAt DESC
     """)
     Page<VehicleEntity> findAll(@Param("companyId") Long companyId, @Param("status") VehicleStatus status, @Param("keyword") String keyword, Pageable pageable);
 

--- a/admin/src/main/java/kernel360/ckt/admin/infra/jpa/VehicleJpaRepository.java
+++ b/admin/src/main/java/kernel360/ckt/admin/infra/jpa/VehicleJpaRepository.java
@@ -1,6 +1,5 @@
 package kernel360.ckt.admin.infra.jpa;
 
-import javax.swing.text.html.Option;
 import kernel360.ckt.core.domain.entity.VehicleEntity;
 import kernel360.ckt.core.domain.enums.VehicleStatus;
 import org.springframework.data.domain.Page;
@@ -17,14 +16,15 @@ public interface VehicleJpaRepository extends JpaRepository<VehicleEntity, Long>
     @Query("""
         SELECT v FROM VehicleEntity v
         WHERE  v.deleteYn = false
+        AND (v.company.id = :companyId)
         AND (:status IS NULL OR v.status = :status)
         AND (:keyword IS NULL OR v.registrationNumber LIKE %:keyword% OR v.modelName LIKE %:keyword%)
     """)
-    Page<VehicleEntity> findAll(@Param("status") VehicleStatus status, @Param("keyword") String keyword, Pageable pageable);
+    Page<VehicleEntity> findAll(@Param("companyId") Long companyId, @Param("status") VehicleStatus status, @Param("keyword") String keyword, Pageable pageable);
 
-    Optional<VehicleEntity> findByIdAndDeleteYnFalse(Long vehicleId);
+    Optional<VehicleEntity> findByIdAndCompanyIdAndDeleteYnFalse(Long vehicleId, Long companyId);
 
-    Optional<VehicleEntity> findByRegistrationNumberAndDeleteYnFalse(String registrationNumber);
+    Optional<VehicleEntity> findByCompanyIdAndRegistrationNumberAndDeleteYnFalse(Long companyId, String registrationNumber);
 
     @Query("""
         SELECT v
@@ -33,14 +33,15 @@ public interface VehicleJpaRepository extends JpaRepository<VehicleEntity, Long>
             AND r.status = 'RENTED'
             AND r.pickupAt <= :returnAt
             AND r.returnAt >= :pickupAt
-        WHERE
-            v.deleteYn = false
+        WHERE v.deleteYn = false
+        AND (v.company.id = :companyId)
         AND
             (LOWER(v.registrationNumber) LIKE LOWER(CONCAT('%', :keyword, '%')) OR
              LOWER(v.modelName) LIKE LOWER(CONCAT('%', :keyword, '%')))
         AND r.id IS NULL
     """)
     List<VehicleEntity> searchAvailableVehiclesByKeyword(
+        @Param("companyId") Long companyId,
         @Param("keyword") String keyword,
         @Param("pickupAt") LocalDateTime pickupAt,
         @Param("returnAt") LocalDateTime returnAt

--- a/admin/src/main/java/kernel360/ckt/admin/infra/jpa/VehicleJpaRepository.java
+++ b/admin/src/main/java/kernel360/ckt/admin/infra/jpa/VehicleJpaRepository.java
@@ -1,5 +1,6 @@
 package kernel360.ckt.admin.infra.jpa;
 
+import javax.swing.text.html.Option;
 import kernel360.ckt.core.domain.entity.VehicleEntity;
 import kernel360.ckt.core.domain.enums.VehicleStatus;
 import org.springframework.data.domain.Page;
@@ -15,12 +16,15 @@ import java.util.Optional;
 public interface VehicleJpaRepository extends JpaRepository<VehicleEntity, Long> {
     @Query("""
         SELECT v FROM VehicleEntity v
-        WHERE (:status IS NULL OR v.status = :status)
+        WHERE  v.deleteYn = false
+        AND (:status IS NULL OR v.status = :status)
         AND (:keyword IS NULL OR v.registrationNumber LIKE %:keyword% OR v.modelName LIKE %:keyword%)
     """)
     Page<VehicleEntity> findAll(@Param("status") VehicleStatus status, @Param("keyword") String keyword, Pageable pageable);
 
-    Optional<VehicleEntity> findByRegistrationNumber(String registrationNumber);
+    Optional<VehicleEntity> findByIdAndDeleteYnFalse(Long vehicleId);
+
+    Optional<VehicleEntity> findByRegistrationNumberAndDeleteYnFalse(String registrationNumber);
 
     @Query("""
         SELECT v
@@ -30,6 +34,8 @@ public interface VehicleJpaRepository extends JpaRepository<VehicleEntity, Long>
             AND r.pickupAt <= :returnAt
             AND r.returnAt >= :pickupAt
         WHERE
+            v.deleteYn = false
+        AND
             (LOWER(v.registrationNumber) LIKE LOWER(CONCAT('%', :keyword, '%')) OR
              LOWER(v.modelName) LIKE LOWER(CONCAT('%', :keyword, '%')))
         AND r.id IS NULL

--- a/admin/src/main/java/kernel360/ckt/admin/ui/VehicleController.java
+++ b/admin/src/main/java/kernel360/ckt/admin/ui/VehicleController.java
@@ -25,29 +25,36 @@ import java.util.List;
 @RequestMapping("/api/v1/vehicles")
 @RestController
 public class VehicleController {
+    private static final String X_USER_ID_HEADER = "X-User-Id";
+
     private final VehicleService vehicleService;
 
     @PostMapping
-    CommonResponse<VehicleResponse> create(@RequestBody @Valid VehicleCreateRequest request) {
+    CommonResponse<VehicleResponse> create(
+        @RequestHeader(X_USER_ID_HEADER) Long companyId,
+        @RequestBody @Valid VehicleCreateRequest request
+    ) {
         log.info("차량 추가 요청, 사용자 리퀘스트: {}", request);
-        final CreateVehicleCommand command = request.toCommand();
+        final CreateVehicleCommand command = request.toCommand(companyId);
         final VehicleEntity vehicleEntity = vehicleService.create(command);
         return CommonResponse.success(VehicleResponse.from(vehicleEntity));
     }
 
     @PutMapping("/{id}")
     CommonResponse<VehicleResponse> updateVehicle(
+        @RequestHeader(X_USER_ID_HEADER) Long companyId,
         @PathVariable Long id,
         @RequestBody VehicleUpdateRequest request
     ) {
         log.info("차량 정보 수정 요청, id: {}, 사용자 리퀘스트: {}", id, request);
-        final UpdateVehicleCommand command = request.toCommand();
+        final UpdateVehicleCommand command = request.toCommand(companyId);
         final VehicleEntity vehicleEntity = vehicleService.update(id, command);
         return CommonResponse.success(VehicleResponse.from(vehicleEntity));
     }
 
     @GetMapping
     CommonResponse<VehicleListResponse> getAllVehicles(
+        @RequestHeader(X_USER_ID_HEADER) Long companyId,
         @RequestParam(defaultValue = "0") int page,
         @RequestParam(defaultValue = "10") int size,
         @RequestParam(required = false) VehicleStatus status,
@@ -55,28 +62,37 @@ public class VehicleController {
     ) {
         log.info("차량 목록 조회 요청, page: {}, size: {}, status: {}, keyword: {}", page, size, status, keyword);
         Pageable pageable = PageRequest.of(page, size);
-        Page<VehicleEntity> vehiclePage = vehicleService.searchVehicles(status, keyword, pageable);
+        Page<VehicleEntity> vehiclePage = vehicleService.searchVehicles(companyId, status, keyword, pageable);
         final VehicleListResponse vehicleResponse = VehicleListResponse.from(vehiclePage);
         return CommonResponse.success(vehicleResponse);
     }
 
     @GetMapping("/{id}")
-    CommonResponse<VehicleResponse> selectVehicle(@PathVariable Long id) {
+    CommonResponse<VehicleResponse> selectVehicle(
+        @RequestHeader(X_USER_ID_HEADER) Long companyId,
+        @PathVariable Long id
+    ) {
         log.info("차량 상세 정보 조회 요청, id: {}", id);
-        final VehicleEntity vehicleEntity = vehicleService.findById(id);
+        final VehicleEntity vehicleEntity = vehicleService.findById(id, companyId);
         return CommonResponse.success(VehicleResponse.from(vehicleEntity));
     }
 
     @DeleteMapping("/{id}")
-    CommonResponse<Void> deleteVehicle(@PathVariable Long id) {
+    CommonResponse<Void> deleteVehicle(
+        @RequestHeader(X_USER_ID_HEADER) Long companyId,
+        @PathVariable Long id
+    ) {
         log.info("차량 삭제 요청, id: {}", id);
-        vehicleService.delete(id);
+        vehicleService.delete(id, companyId);
         return CommonResponse.success(null);
     }
 
     @GetMapping("/search")
-    public CommonResponse<VehicleKeywordListResponse> searchKeyword(VehicleKeywordRequest request) {
-        final List<VehicleEntity> vehicles = vehicleService.searchKeyword(request.toCommand());
+    public CommonResponse<VehicleKeywordListResponse> searchKeyword(
+        @RequestHeader(X_USER_ID_HEADER) Long companyId,
+        VehicleKeywordRequest request
+    ) {
+        final List<VehicleEntity> vehicles = vehicleService.searchKeyword(request.toCommand(companyId));
         return CommonResponse.success(VehicleKeywordListResponse.from(vehicles));
     }
 }

--- a/admin/src/main/java/kernel360/ckt/admin/ui/dto/request/VehicleCreateRequest.java
+++ b/admin/src/main/java/kernel360/ckt/admin/ui/dto/request/VehicleCreateRequest.java
@@ -18,8 +18,9 @@ public record VehicleCreateRequest(
     String transmissionType,
     @Size(max = 500, message = "메모는 500자 이하이어야 합니다.") String memo
 ) {
-    public CreateVehicleCommand toCommand() {
+    public CreateVehicleCommand toCommand(Long companyId) {
         return new CreateVehicleCommand(
+            companyId,
             this.registrationNumber,
             this.modelYear,
             this.manufacturer,

--- a/admin/src/main/java/kernel360/ckt/admin/ui/dto/request/VehicleKeywordRequest.java
+++ b/admin/src/main/java/kernel360/ckt/admin/ui/dto/request/VehicleKeywordRequest.java
@@ -26,8 +26,9 @@ public record VehicleKeywordRequest(
         }
     }
 
-    public VehicleKeywordCommand toCommand() {
+    public VehicleKeywordCommand toCommand(Long companyId) {
         return new VehicleKeywordCommand(
+            companyId,
             this.keyword,
             this.pickupAt,
             this.returnAt

--- a/admin/src/main/java/kernel360/ckt/admin/ui/dto/request/VehicleUpdateRequest.java
+++ b/admin/src/main/java/kernel360/ckt/admin/ui/dto/request/VehicleUpdateRequest.java
@@ -18,8 +18,9 @@ public record VehicleUpdateRequest(
     String transmissionType,
     @Size(max = 500, message = "메모는 500자 이하이어야 합니다.") String memo
 ) {
-    public UpdateVehicleCommand toCommand() {
+    public UpdateVehicleCommand toCommand(Long companyId) {
         return new UpdateVehicleCommand(
+            companyId,
             this.modelYear,
             this.manufacturer,
             this.modelName,

--- a/admin/src/main/java/kernel360/ckt/admin/ui/dto/response/VehicleResponse.java
+++ b/admin/src/main/java/kernel360/ckt/admin/ui/dto/response/VehicleResponse.java
@@ -18,6 +18,8 @@ public record VehicleResponse(
     String transmissionTypeName,
     VehicleStatus status,
     String statusName,
+    Double lat,
+    Double lon,
     String memo
 ) {
     public static VehicleResponse from(VehicleEntity vehicleEntity) {
@@ -34,6 +36,8 @@ public record VehicleResponse(
             vehicleEntity.getTransmissionType().getValue(),
             vehicleEntity.getStatus(),
             vehicleEntity.getStatus().getValue(),
+            vehicleEntity.getLat(),
+            vehicleEntity.getLon(),
             vehicleEntity.getMemo()
         );
     }

--- a/core/src/main/java/kernel360/ckt/core/common/response/ErrorResponse.java
+++ b/core/src/main/java/kernel360/ckt/core/common/response/ErrorResponse.java
@@ -14,7 +14,7 @@ public class ErrorResponse {
     }
 
     public static ErrorResponse from(ErrorCode errorCode) {
-        return new ErrorResponse(String.valueOf(errorCode.getStatus()), errorCode.getMessage());
+        return new ErrorResponse(String.valueOf(errorCode.getCode()), errorCode.getMessage());
     }
 
     public static ErrorResponse from(String code, String message) {

--- a/core/src/main/java/kernel360/ckt/core/domain/entity/VehicleEntity.java
+++ b/core/src/main/java/kernel360/ckt/core/domain/entity/VehicleEntity.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import kernel360.ckt.core.domain.enums.FuelType;
 import kernel360.ckt.core.domain.enums.TransmissionType;
 import kernel360.ckt.core.domain.enums.VehicleStatus;
+import kernel360.ckt.core.domain.persistence.BooleanToYNConverter;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -56,6 +57,10 @@ public class VehicleEntity extends BaseTimeEntity {
     @Lob
     private String memo;
 
+    @Column(nullable = false, length = 1)
+    @Convert(converter = BooleanToYNConverter.class)
+    private Boolean deleteYn = false;
+
     private VehicleEntity(String registrationNumber, String modelYear, String manufacturer, String modelName,
                           String batteryVoltage, FuelType fuelType, TransmissionType transmissionType,
                           VehicleStatus status, String memo) {
@@ -90,14 +95,13 @@ public class VehicleEntity extends BaseTimeEntity {
         this.memo = memo;
     }
 
-    public void initLocation() {
-        this.lat = 37.4955498697675;
-        this.lon = 127.029293901519;
-    }
-
     public void updateLocation(Double lat, Double lon, Long odometer) {
         this.lat = lat;
         this.lon = lon;
         this.odometer = this.odometer + odometer;
+    }
+
+    public void delete() {
+        this.deleteYn = true;
     }
 }

--- a/core/src/main/java/kernel360/ckt/core/domain/entity/VehicleEntity.java
+++ b/core/src/main/java/kernel360/ckt/core/domain/entity/VehicleEntity.java
@@ -18,7 +18,11 @@ public class VehicleEntity extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false, length = 10, unique = true)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "company_id")
+    private CompanyEntity company;
+
+    @Column(nullable = false, length = 10)
     private String registrationNumber;
 
     @Column(length = 4)
@@ -61,9 +65,10 @@ public class VehicleEntity extends BaseTimeEntity {
     @Convert(converter = BooleanToYNConverter.class)
     private Boolean deleteYn = false;
 
-    private VehicleEntity(String registrationNumber, String modelYear, String manufacturer, String modelName,
+    private VehicleEntity(CompanyEntity company, String registrationNumber, String modelYear, String manufacturer, String modelName,
                           String batteryVoltage, FuelType fuelType, TransmissionType transmissionType,
                           VehicleStatus status, String memo) {
+        this.company = company;
         this.registrationNumber = registrationNumber;
         this.modelYear = modelYear;
         this.manufacturer = manufacturer;
@@ -75,10 +80,10 @@ public class VehicleEntity extends BaseTimeEntity {
         this.memo = memo;
     }
 
-    public static VehicleEntity create(String registrationNumber, String modelYear, String manufacturer, String modelName,
+    public static VehicleEntity create(CompanyEntity company, String registrationNumber, String modelYear, String manufacturer, String modelName,
                                        String batteryVoltage, FuelType fuelType, TransmissionType transmissionType,
                                        VehicleStatus status, String memo) {
-        return new VehicleEntity(registrationNumber, modelYear, manufacturer, modelName,
+        return new VehicleEntity(company, registrationNumber, modelYear, manufacturer, modelName,
             batteryVoltage, fuelType, transmissionType, status, memo);
     }
 

--- a/core/src/main/java/kernel360/ckt/core/domain/persistence/BooleanToYNConverter.java
+++ b/core/src/main/java/kernel360/ckt/core/domain/persistence/BooleanToYNConverter.java
@@ -1,0 +1,26 @@
+package kernel360.ckt.core.domain.persistence;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+/**
+ * Boolean 타입 (true/false)을 MySQL CHAR(1) 타입 ('Y'/'N')으로 변환하는 JPA 컨버터.
+ * 엔티티 필드에 @Convert(converter = BooleanToYNConverter.class) 어노테이션과 함께 사용됩니다.
+ */
+@Converter
+public class BooleanToYNConverter implements AttributeConverter<Boolean, String> {
+    @Override
+    public String convertToDatabaseColumn(Boolean attribute) {
+        if (attribute == null) {
+            return "N"; //
+        }
+        return attribute ? "Y" : "N";
+    }
+    @Override
+    public Boolean convertToEntityAttribute(String dbData) {
+        if (dbData == null || dbData.trim().isEmpty()) {
+            return false;
+        }
+        return "Y".equalsIgnoreCase(dbData.trim());
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #87 



## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 설명해 주세요. (이미지 첨부 가능) -->

- 차량 도메인 삭제 여부 추가
- 차량 도메인 회사 FK 추가 (회사의 차량으로 변경)
- 차량 목록 조회시 생성일 기준으로 역정렬 처리
- 공통 에러 error code가 아닌 status code가 매핑되어 내려가는 이슈 수정


## 👀 리뷰어 가이드라인
<!-- 리뷰어가 중점적으로 확인해야 할 사항을 작성해 주세요. -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

- 공통 에러 프론트에서 error code 로 처리하기 위해 변경하였는데, 영향도 체크 부탁드립니다.
- 차량 삭제 시 deleteYn으로 처리하기 위해 `BooleanToYNConverter` 추가하였습니다.
- 타 회사로 접근 시 모든 차량이 전부 보이는 이슈로 회사에 등록된 차량이 되도록 회사 fk 추가하였습니다.
