### PR TITLE
feat: 운행 차량 판별 및 통계 로직 개선

### DIFF
--- a/admin/src/main/java/kernel360/ckt/admin/application/port/RentalRepository.java
+++ b/admin/src/main/java/kernel360/ckt/admin/application/port/RentalRepository.java
@@ -67,6 +67,8 @@ public interface RentalRepository {
         Long excludeRentalId
     );
 
+    long countVehiclesByVehicleIds(List<Long> vehicleIds);
+
     /**
      * 특정 상태를 가진 대여 목록을 조회합니다.
      *

--- a/admin/src/main/java/kernel360/ckt/admin/application/port/RentalRepository.java
+++ b/admin/src/main/java/kernel360/ckt/admin/application/port/RentalRepository.java
@@ -67,24 +67,6 @@ public interface RentalRepository {
         Long excludeRentalId
     );
 
-    long countVehiclesByVehicleIds(List<Long> vehicleIds);
-
-    /**
-     * 특정 상태를 가진 대여 목록을 조회합니다.
-     *
-     * @param status 조회할 대여 상태
-     * @return 해당 상태의 대여 목록
-     */
-    List<RentalEntity> findRentalsByStatus(RentalStatus status);
-
-    /**
-     * 특정 상태를 가진 차량 수를 계산합니다.
-     *
-     * @param status 대상 대여 상태
-     * @return 해당 상태의 차량 수
-     */
-    long countVehiclesByStatus(RentalStatus status);
-
     /**
      * 현재 대여 중(RENTED 상태)인 고객 수를 조회합니다.
      * 동일 고객이 여러 대여건을 가지고 있어도 1명으로 계산합니다.

--- a/admin/src/main/java/kernel360/ckt/admin/application/service/VehicleControlTowerService.java
+++ b/admin/src/main/java/kernel360/ckt/admin/application/service/VehicleControlTowerService.java
@@ -3,10 +3,8 @@ package kernel360.ckt.admin.application.service;
 import kernel360.ckt.admin.application.port.VehicleRepository;
 import kernel360.ckt.admin.domain.projection.RunningVehicleProjection;
 import kernel360.ckt.admin.infra.basic.TraceLogQueryRepository;
-import kernel360.ckt.admin.infra.jpa.RentalJpaRepository;
 import kernel360.ckt.admin.ui.dto.response.ControlTowerSummaryResponse;
 import kernel360.ckt.admin.ui.dto.response.RunningVehicleResponse;
-import kernel360.ckt.core.domain.enums.RentalStatus;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -18,7 +16,6 @@ public class VehicleControlTowerService {
 
     private final VehicleRepository vehicleRepository;
     private final TraceLogQueryRepository traceLogQueryRepository;
-    private final RentalJpaRepository rentalJpaRepository;
 
     public ControlTowerSummaryResponse getControlTowerSummary() {
         // 전체 차량 수
@@ -30,9 +27,7 @@ public class VehicleControlTowerService {
             .map(RunningVehicleProjection::getVehicleId)
             .toList();
 
-        long running = runningVehicleIds.isEmpty()
-            ? 0
-            : rentalJpaRepository.countVehiclesByVehicleIds(runningVehicleIds);
+        long running = runningVehicleIds.toArray().length;
 
         long stopped = total - running;
 

--- a/admin/src/main/java/kernel360/ckt/admin/application/service/VehicleControlTowerService.java
+++ b/admin/src/main/java/kernel360/ckt/admin/application/service/VehicleControlTowerService.java
@@ -1,0 +1,47 @@
+package kernel360.ckt.admin.application.service;
+
+import kernel360.ckt.admin.application.port.VehicleRepository;
+import kernel360.ckt.admin.domain.projection.RunningVehicleProjection;
+import kernel360.ckt.admin.infra.basic.TraceLogQueryRepository;
+import kernel360.ckt.admin.infra.jpa.RentalJpaRepository;
+import kernel360.ckt.admin.ui.dto.response.ControlTowerSummaryResponse;
+import kernel360.ckt.admin.ui.dto.response.RunningVehicleResponse;
+import kernel360.ckt.core.domain.enums.RentalStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Service
+public class VehicleControlTowerService {
+
+    private final VehicleRepository vehicleRepository;
+    private final TraceLogQueryRepository traceLogQueryRepository;
+    private final RentalJpaRepository rentalJpaRepository;
+
+    public ControlTowerSummaryResponse getControlTowerSummary() {
+        // 전체 차량 수
+        long total = vehicleRepository.count();
+
+        // 운행 중 차량 리스트
+        List<RunningVehicleProjection> runningProjections = traceLogQueryRepository.findRunningVehicleLocations();
+        List<Long> runningVehicleIds = runningProjections.stream()
+            .map(RunningVehicleProjection::getVehicleId)
+            .toList();
+
+        long running = runningVehicleIds.isEmpty()
+            ? 0
+            : rentalJpaRepository.countVehiclesByVehicleIds(runningVehicleIds);
+
+        long stopped = total - running;
+
+        return ControlTowerSummaryResponse.of((int) total, (int) running, (int) stopped);
+    }
+
+    public List<RunningVehicleResponse> getRunningVehiclesFromNativeQuery() {
+        return traceLogQueryRepository.findRunningVehicleLocations().stream()
+            .map(RunningVehicleResponse::from)
+            .toList();
+    }
+}

--- a/admin/src/main/java/kernel360/ckt/admin/application/service/VehicleService.java
+++ b/admin/src/main/java/kernel360/ckt/admin/application/service/VehicleService.java
@@ -8,15 +8,11 @@ import kernel360.ckt.admin.application.service.command.CreateVehicleCommand;
 import kernel360.ckt.admin.application.service.command.VehicleKeywordCommand;
 import kernel360.ckt.admin.application.service.command.UpdateVehicleCommand;
 import kernel360.ckt.admin.infra.jpa.RentalJpaRepository;
-import kernel360.ckt.admin.ui.dto.response.ControlTowerSummaryResponse;
-import kernel360.ckt.admin.ui.dto.response.GpsPointResponse;
-import kernel360.ckt.admin.ui.dto.response.RunningVehicleResponse;
 import kernel360.ckt.core.common.error.VehicleErrorCode;
 import kernel360.ckt.core.common.exception.CustomException;
 import kernel360.ckt.core.domain.entity.CompanyEntity;
 import kernel360.ckt.core.domain.entity.RentalEntity;
 import kernel360.ckt.core.domain.entity.VehicleEntity;
-import kernel360.ckt.core.domain.enums.RentalStatus;
 import kernel360.ckt.core.domain.enums.VehicleStatus;
 import kernel360.ckt.admin.application.port.RentalRepository;
 import kernel360.ckt.admin.application.port.VehicleRepository;
@@ -25,11 +21,9 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
-import com.fasterxml.jackson.databind.JsonNode;
 
 
 import java.util.List;
-import java.util.Optional;
 
 @RequiredArgsConstructor
 @Service
@@ -119,51 +113,6 @@ public class VehicleService {
 
     public List<VehicleEntity> searchKeyword(VehicleKeywordCommand command) {
         return vehicleRepository.searchAvailableVehiclesByKeyword(command.getCompanyId(), command.getKeyword(), command.getPickupAt(), command.getReturnAt());
-    }
-
-    public ControlTowerSummaryResponse getControlTowerSummary() {
-        long total = vehicleRepository.count();
-        long running = rentalRepository.countVehiclesByStatus(RentalStatus.RENTED);
-        long stopped = total - running;
-        return ControlTowerSummaryResponse.of((int) total, (int) running, (int) stopped);
-    }
-
-    public List<RunningVehicleResponse> getVehicleLocations() {
-        List<RentalEntity> runningRentals = rentalJpaRepository.findRentedRentals();
-
-        return runningRentals.stream()
-            .map(rental -> {
-                Long vehicleId = rental.getVehicle().getId();
-                Optional<String> traceJsonOpt = rentalJpaRepository.findLatestTraceJsonByVehicleId(vehicleId);
-
-                GpsPointResponse location = traceJsonOpt
-                    .map(this::parseGpsFromTraceJson)
-                    .orElse(null);
-
-                return RunningVehicleResponse.from(rental, location);
-            })
-            .toList();
-    }
-
-    private GpsPointResponse parseGpsFromTraceJson(String traceJson) {
-        try {
-            ObjectMapper mapper = new ObjectMapper();
-            JsonNode root = mapper.readTree(traceJson);
-
-            if (root.isArray() && root.size() > 0) {
-                JsonNode last = root.get(root.size() - 1); // 마지막 위치 정보
-
-                return new GpsPointResponse(
-                    last.path("lat").asText(null),
-                    last.path("lon").asText(null),
-                    last.path("ang").asText(null),
-                    last.path("spd").asText(null)
-                );
-            }
-        } catch (Exception e) {
-            // 로그 남기거나 무시
-        }
-        return null;
     }
 
 }

--- a/admin/src/main/java/kernel360/ckt/admin/domain/projection/RunningVehicleProjection.java
+++ b/admin/src/main/java/kernel360/ckt/admin/domain/projection/RunningVehicleProjection.java
@@ -1,0 +1,12 @@
+package kernel360.ckt.admin.domain.projection;
+
+public interface RunningVehicleProjection {
+    Long getVehicleId();
+    String getRegistrationNumber();
+    String getManufacturer();
+    String getModelName();
+    String getCustomerName();
+    String getLat();
+    String getLon();
+    String getSpd();
+}

--- a/admin/src/main/java/kernel360/ckt/admin/infra/RentalRepositoryAdapter.java
+++ b/admin/src/main/java/kernel360/ckt/admin/infra/RentalRepositoryAdapter.java
@@ -40,13 +40,8 @@ public class RentalRepositoryAdapter implements RentalRepository {
     }
 
     @Override
-    public List<RentalEntity> findRentalsByStatus(RentalStatus status) {
-        return rentalJpaRepository.findRentalsByStatus(status);
-    }
-
-    @Override
-    public long countVehiclesByStatus(RentalStatus status) {
-        return rentalJpaRepository.countVehiclesByStatus(status);
+    public long countVehiclesByVehicleIds(List<Long> vehicleIds) {
+        return rentalJpaRepository.countVehiclesByVehicleIds(vehicleIds);
     }
 
     @Override

--- a/admin/src/main/java/kernel360/ckt/admin/infra/RentalRepositoryAdapter.java
+++ b/admin/src/main/java/kernel360/ckt/admin/infra/RentalRepositoryAdapter.java
@@ -40,10 +40,5 @@ public class RentalRepositoryAdapter implements RentalRepository {
     }
 
     @Override
-    public long countVehiclesByVehicleIds(List<Long> vehicleIds) {
-        return rentalJpaRepository.countVehiclesByVehicleIds(vehicleIds);
-    }
-
-    @Override
     public long countRentedCustomers() { return rentalJpaRepository.countRentedCustomers(); }
 }

--- a/admin/src/main/java/kernel360/ckt/admin/infra/basic/TraceLogQueryRepository.java
+++ b/admin/src/main/java/kernel360/ckt/admin/infra/basic/TraceLogQueryRepository.java
@@ -1,0 +1,41 @@
+package kernel360.ckt.admin.infra.basic;
+
+import kernel360.ckt.admin.domain.projection.RunningVehicleProjection;
+import kernel360.ckt.core.domain.entity.VehicleEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
+
+/**
+ * 시동 ON된 차량의 최신 위치 정보를 가져오는 native query repository
+ */
+public interface TraceLogQueryRepository extends JpaRepository<VehicleEntity, Long> {
+
+    @Query(value = """
+    SELECT
+        v.id AS vehicleId,
+        v.registration_number AS registrationNumber,
+        v.manufacturer AS manufacturer,
+        v.model_name AS modelName,
+        cu.customer_name AS customerName,
+        CAST(v.lat AS CHAR) AS lat,
+        CAST(v.lon AS CHAR) AS lon,
+        CAST(v.odometer AS CHAR) AS spd
+    FROM vehicle v
+    JOIN (
+        SELECT ve.vehicle_id, MAX(ve.created_at) AS last_event_time
+        FROM vehicle_event ve
+        GROUP BY ve.vehicle_id
+    ) latest_ve ON v.id = latest_ve.vehicle_id
+    JOIN vehicle_event ve
+      ON ve.vehicle_id = latest_ve.vehicle_id
+     AND ve.created_at = latest_ve.last_event_time
+     AND ve.type = 'ON'
+    LEFT JOIN rental r
+      ON r.vehicle_id = v.id
+     AND r.status = 'RENTED'
+    LEFT JOIN customer cu ON r.customer_id = cu.id
+    """, nativeQuery = true)
+    List<RunningVehicleProjection> findRunningVehicleLocations();
+}

--- a/admin/src/main/java/kernel360/ckt/admin/infra/jpa/RentalJpaRepository.java
+++ b/admin/src/main/java/kernel360/ckt/admin/infra/jpa/RentalJpaRepository.java
@@ -57,14 +57,6 @@ public interface RentalJpaRepository extends JpaRepository<RentalEntity, Long> {
     @EntityGraph(attributePaths = {"company", "vehicle", "customer"})
     Optional<RentalEntity> findById(Long id);
 
-    @Query("""
-    SELECT COUNT(DISTINCT r.vehicle.id)
-    FROM RentalEntity r
-    WHERE r.vehicle.id IN :vehicleIds
-""")
-    long countVehiclesByVehicleIds(@Param("vehicleIds") List<Long> vehicleIds);
-    List<RentalEntity> findRentedRentals();
-
     @Query("SELECT COUNT(DISTINCT r.customer.id) FROM RentalEntity r WHERE r.status = 'RENTED'")
     long countRentedCustomers();
 }

--- a/admin/src/main/java/kernel360/ckt/admin/infra/jpa/RentalJpaRepository.java
+++ b/admin/src/main/java/kernel360/ckt/admin/infra/jpa/RentalJpaRepository.java
@@ -58,46 +58,11 @@ public interface RentalJpaRepository extends JpaRepository<RentalEntity, Long> {
     Optional<RentalEntity> findById(Long id);
 
     @Query("""
-        SELECT r FROM RentalEntity r
-        JOIN FETCH r.customer
-        JOIN FETCH r.vehicle
-        WHERE r.status = :status
-    """)
-    List<RentalEntity> findRentalsByStatus(@Param("status") RentalStatus status);
-
-    @Query("""
-        SELECT COUNT(DISTINCT r.vehicle.id)
-        FROM RentalEntity r
-        WHERE r.status = :status
-    """)
-    long countVehiclesByStatus(@Param("status") RentalStatus status);
-
-    @Query(value = """
-    SELECT vtl.trace_data_json
-    FROM vehicle_trace_log vtl
-    JOIN route r ON vtl.route_id = r.id
-    JOIN driving_log dl ON r.driving_log_id = dl.id
-    JOIN rental rt ON dl.rental_id = rt.id
-    WHERE rt.vehicle_id = :vehicleId
-    ORDER BY vtl.occurred_at DESC
-    LIMIT 1
-""", nativeQuery = true)
-    Optional<String> findLatestTraceJsonByVehicleId(@Param("vehicleId") Long vehicleId);
-
-    @Query("""
-    SELECT r FROM RentalEntity r
-    JOIN FETCH r.customer c
-    JOIN FETCH r.vehicle v
-    WHERE r.status = 'RENTED'
-    AND r.pickupAt = (
-        SELECT MAX(r2.pickupAt)
-        FROM RentalEntity r2
-        WHERE r2.vehicle = r.vehicle
-        AND r2.status = 'RENTED'
-    )
-    ORDER BY r.pickupAt DESC
-
+    SELECT COUNT(DISTINCT r.vehicle.id)
+    FROM RentalEntity r
+    WHERE r.vehicle.id IN :vehicleIds
 """)
+    long countVehiclesByVehicleIds(@Param("vehicleIds") List<Long> vehicleIds);
     List<RentalEntity> findRentedRentals();
 
     @Query("SELECT COUNT(DISTINCT r.customer.id) FROM RentalEntity r WHERE r.status = 'RENTED'")

--- a/admin/src/main/java/kernel360/ckt/admin/ui/VehicleControlTowerController.java
+++ b/admin/src/main/java/kernel360/ckt/admin/ui/VehicleControlTowerController.java
@@ -1,7 +1,7 @@
 package kernel360.ckt.admin.ui;
 
+import kernel360.ckt.admin.application.service.VehicleControlTowerService;
 import kernel360.ckt.admin.ui.dto.response.ControlTowerSummaryResponse;
-import kernel360.ckt.admin.application.service.VehicleService;
 import kernel360.ckt.admin.ui.dto.response.RunningVehicleResponse;
 import kernel360.ckt.core.common.response.CommonResponse;
 import lombok.RequiredArgsConstructor;
@@ -16,16 +16,16 @@ import java.util.List;
 @RestController
 public class VehicleControlTowerController {
 
-    private final VehicleService vehicleService;
+    private final VehicleControlTowerService vehicleControlTowerService;
 
     @GetMapping("/status")
     public CommonResponse<ControlTowerSummaryResponse> getControlTowerSummary() {
-        return CommonResponse.success(vehicleService.getControlTowerSummary());
+        return CommonResponse.success(vehicleControlTowerService.getControlTowerSummary());
     }
 
     @GetMapping("/vehicles/location")
     public CommonResponse<List<RunningVehicleResponse>> getVehicleLocations() {
-        return CommonResponse.success(vehicleService.getVehicleLocations());
+        return CommonResponse.success(vehicleControlTowerService.getRunningVehiclesFromNativeQuery());
     }
 
 }

--- a/admin/src/main/java/kernel360/ckt/admin/ui/dto/response/RunningVehicleResponse.java
+++ b/admin/src/main/java/kernel360/ckt/admin/ui/dto/response/RunningVehicleResponse.java
@@ -1,6 +1,6 @@
 package kernel360.ckt.admin.ui.dto.response;
 
-import kernel360.ckt.core.domain.entity.RentalEntity;
+import kernel360.ckt.admin.domain.projection.RunningVehicleProjection;
 
 public record RunningVehicleResponse(
     Long vehicleId,
@@ -10,20 +10,18 @@ public record RunningVehicleResponse(
     String customerName,
     String lat,
     String lon,
-    String ang,
     String spd
 ) {
-    public static RunningVehicleResponse from(RentalEntity rental, GpsPointResponse location) {
+    public static RunningVehicleResponse from(RunningVehicleProjection p) {
         return new RunningVehicleResponse(
-            rental.getVehicle().getId(),
-            rental.getVehicle().getRegistrationNumber(),
-            rental.getVehicle().getManufacturer(),
-            rental.getVehicle().getModelName(),
-            rental.getCustomer().getCustomerName(),
-            location != null ? location.lat() : null,
-            location != null ? location.lon() : null,
-            location != null ? location.ang() : null,
-            location != null ? location.spd() : null
+            p.getVehicleId(),
+            p.getRegistrationNumber(),
+            p.getManufacturer(),
+            p.getModelName(),
+            p.getCustomerName(),
+            p.getLat(),
+            p.getLon(),
+            p.getSpd()
         );
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
<!-- ex) #이슈번호[, #이슈번호] -->

> #85 


## 📝 작업 내용
- 기존 RentalStatus.RENTED 기준의 운행 차량 통계 계산 방식 제거
- TraceLogQueryRepository를 기반으로 실시간 운행 차량 목록 조회
- 조회된 운행 차량 ID 리스트를 기반으로 Rental 테이블에서 운행중인 차량 수 계산
- RentalRepository에 countVehiclesByVehicleIds(List<Long>) 메서드 추가
- RentalRepositoryAdapter에서 해당 메서드 위임 구현
- VehicleControlTowerService에서 getControlTowerSummary 로직 전면 수정
- Controller와 Service 책임 분리
- RunningVehicleResponse DTO에서 RunningVehicleProjection 기반 → Rental 기반 구조로 리팩토링
- trace_log에서 최신 위치 정보를 가져오기 위한 native 쿼리 추가 (findLatestTraceJsonByVehicleId)
- 최신 RENTED 상태의 대여 정보만 추출하는 JPQL 쿼리 추가 (findRentedRentals)

## 👀 리뷰어 가이드라인
- 기존의 "운행 중 = RENTED 상태" 기준에서 벗어나, 실제 시동 ON 차량 기준으로 통계를 재정의한 구조입니다.
- getControlTowerSummary()에서 총 차량 수 대비 운행 중 차량 수, 정지 차량 수 계산 방식이 새롭게 변경된 부분을 중점적으로 봐주세요.
- RunningVehicleResponse 매핑 방식 변경 및 trace_log 쿼리 결과 매핑도 리뷰 부탁드립니다.
- 쿼리 성능상 문제가 있거나, trace_log 관련 설계 개선 의견도 환영합니다.
