### PR TITLE
feat: 고객 대여 상세 정보 API 구현

### DIFF
--- a/admin/src/main/java/kernel360/ckt/admin/application/port/RentalRepository.java
+++ b/admin/src/main/java/kernel360/ckt/admin/application/port/RentalRepository.java
@@ -74,4 +74,40 @@ public interface RentalRepository {
      * @return 대여 중인 고객 수
      */
     long countRentedCustomers();
+
+    /**
+     * 특정 고객의 최신 대여 정보를 상태 조건과 함께 조회합니다.
+     * 차량 정보도 함께 조회(fetch join)합니다.
+     *
+     * @param customerId 고객 ID
+     * @param status 조회할 대여 상태
+     * @return 조건에 해당하는 최신 대여 정보 (없으면 Optional.empty)
+     */
+    Optional<RentalEntity> findLatestRentalByCustomerIdAndStatus(Long customerId, RentalStatus status);
+
+    /**
+     * 특정 고객의 전체 대여 이력을 최신순으로 조회합니다.
+     * 각 대여건의 차량 정보도 함께 조회(fetch join)합니다.
+     *
+     * @param customerId 고객 ID
+     * @return 해당 고객의 대여 이력 목록
+     */
+    List<RentalEntity> findAllByCustomerIdFetchVehicle(Long customerId);
+
+    /**
+     * 특정 고객의 전체 대여 건수를 조회합니다.
+     *
+     * @param customerId 고객 ID
+     * @return 전체 대여 횟수
+     */
+    long countByCustomerId(Long customerId);
+
+    /**
+     * 특정 고객이 특정 상태(RENTED 등)로 가지고 있는 대여 건수를 조회합니다.
+     *
+     * @param customerId 고객 ID
+     * @param status 조회할 대여 상태
+     * @return 조건에 맞는 대여 건수
+     */
+    long countByCustomerIdAndStatus(Long customerId, RentalStatus status);
 }

--- a/admin/src/main/java/kernel360/ckt/admin/application/service/CustomerRentalQueryService.java
+++ b/admin/src/main/java/kernel360/ckt/admin/application/service/CustomerRentalQueryService.java
@@ -1,0 +1,50 @@
+package kernel360.ckt.admin.application.service;
+
+import kernel360.ckt.admin.application.port.RentalRepository;
+import kernel360.ckt.admin.infra.jpa.RentalJpaRepository;
+import kernel360.ckt.admin.ui.dto.response.*;
+import kernel360.ckt.core.domain.enums.RentalStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+import static java.util.stream.Collectors.toList;
+
+@RequiredArgsConstructor
+@Service
+public class CustomerRentalQueryService {
+
+    private final RentalRepository rentalRepository;
+
+    public RentalOverviewResponse getRentalSummary(Long customerId) {
+        long total = rentalRepository.countByCustomerId(customerId);
+        long active = rentalRepository.countByCustomerIdAndStatus(customerId, RentalStatus.RENTED);
+
+        // 현재 대여 1건
+        CurrentRentalResponse current = rentalRepository
+            .findLatestRentalByCustomerIdAndStatus(customerId, RentalStatus.RENTED)
+            .map(r -> CurrentRentalResponse.builder()
+                .vehicleName(r.getVehicle().getModelName())
+                .licensePlate(r.getVehicle().getRegistrationNumber())
+                .startDate(r.getPickupAt().toLocalDate())
+                .endDate(r.getReturnAt().toLocalDate())
+                .status(r.getStatus().getValue())
+                .build())
+            .orElse(null);
+
+        // 전체 이력
+        List<RentalHistoryResponse> history = rentalRepository.findAllByCustomerIdFetchVehicle(customerId).stream()
+            .map(r -> RentalHistoryResponse.builder()
+                .reservationId("R-" + r.getId())
+                .vehicleName(r.getVehicle().getModelName())
+                .licensePlate(r.getVehicle().getRegistrationNumber())
+                .startDate(r.getPickupAt().toLocalDate())
+                .endDate(r.getReturnAt().toLocalDate())
+                .status(r.getStatus().getValue())
+                .build())
+            .toList();
+
+        return new RentalOverviewResponse((int) total, (int) active, current, history);
+    }
+}

--- a/admin/src/main/java/kernel360/ckt/admin/application/service/RentalService.java
+++ b/admin/src/main/java/kernel360/ckt/admin/application/service/RentalService.java
@@ -251,7 +251,7 @@ public class RentalService {
      * @throws CustomException 해당 ID의 차량 정보를 찾을 수 없는 경우 발생
      */
     private VehicleEntity findVehicleById(Long companyId, Long vehicleId) {
-        return vehicleRepository.findById(companyId, vehicleId)
+        return vehicleRepository.findById(vehicleId, companyId)
             .orElseThrow(() -> new CustomException(VehicleErrorCode.VEHICLE_NOT_FOUND, vehicleId));
     }
 

--- a/admin/src/main/java/kernel360/ckt/admin/infra/RentalRepositoryAdapter.java
+++ b/admin/src/main/java/kernel360/ckt/admin/infra/RentalRepositoryAdapter.java
@@ -41,4 +41,26 @@ public class RentalRepositoryAdapter implements RentalRepository {
 
     @Override
     public long countRentedCustomers() { return rentalJpaRepository.countRentedCustomers(); }
+
+    @Override
+    public Optional<RentalEntity> findLatestRentalByCustomerIdAndStatus(Long customerId, RentalStatus status) {
+        List<RentalEntity> result = rentalJpaRepository
+            .findFirstRentalByCustomerIdAndStatusFetchVehicle(customerId, status);
+        return result.stream().findFirst();
+    }
+
+    @Override
+    public List<RentalEntity> findAllByCustomerIdFetchVehicle(Long customerId) {
+        return rentalJpaRepository.findAllByCustomerIdFetchVehicle(customerId);
+    }
+
+    @Override
+    public long countByCustomerId(Long customerId) {
+        return rentalJpaRepository.countByCustomerId(customerId);
+    }
+
+    @Override
+    public long countByCustomerIdAndStatus(Long customerId, RentalStatus status) {
+        return rentalJpaRepository.countByCustomerIdAndStatus(customerId, status);
+    }
 }

--- a/admin/src/main/java/kernel360/ckt/admin/infra/jpa/RentalJpaRepository.java
+++ b/admin/src/main/java/kernel360/ckt/admin/infra/jpa/RentalJpaRepository.java
@@ -59,4 +59,27 @@ public interface RentalJpaRepository extends JpaRepository<RentalEntity, Long> {
 
     @Query("SELECT COUNT(DISTINCT r.customer.id) FROM RentalEntity r WHERE r.status = 'RENTED'")
     long countRentedCustomers();
+
+    @Query("""
+    SELECT r FROM RentalEntity r
+    JOIN FETCH r.vehicle
+    WHERE r.customer.id = :customerId AND r.status = :status
+    ORDER BY r.pickupAt DESC
+""")
+    List<RentalEntity> findFirstRentalByCustomerIdAndStatusFetchVehicle(
+        @Param("customerId") Long customerId,
+        @Param("status") RentalStatus status
+    );
+
+    @Query("""
+    SELECT r FROM RentalEntity r
+    JOIN FETCH r.vehicle
+    WHERE r.customer.id = :customerId
+    ORDER BY r.pickupAt DESC
+""")
+    List<RentalEntity> findAllByCustomerIdFetchVehicle(@Param("customerId") Long customerId);
+
+    long countByCustomerId(Long customerId);
+
+    long countByCustomerIdAndStatus(Long customerId, RentalStatus status);
 }

--- a/admin/src/main/java/kernel360/ckt/admin/ui/CustomerController.java
+++ b/admin/src/main/java/kernel360/ckt/admin/ui/CustomerController.java
@@ -1,14 +1,12 @@
 package kernel360.ckt.admin.ui;
 
+import kernel360.ckt.admin.application.service.CustomerRentalQueryService;
 import kernel360.ckt.admin.application.service.CustomerService;
 import kernel360.ckt.admin.application.service.command.CreateCustomerCommand;
 import kernel360.ckt.admin.ui.dto.request.CustomerCreateRequest;
 import kernel360.ckt.admin.ui.dto.request.CustomerKeywordRequest;
 import kernel360.ckt.admin.ui.dto.request.CustomerUpdateRequest;
-import kernel360.ckt.admin.ui.dto.response.CustomerKeywordListResponse;
-import kernel360.ckt.admin.ui.dto.response.CustomerListResponse;
-import kernel360.ckt.admin.ui.dto.response.CustomerResponse;
-import kernel360.ckt.admin.ui.dto.response.CustomerSummaryResponse;
+import kernel360.ckt.admin.ui.dto.response.*;
 import kernel360.ckt.core.common.response.CommonResponse;
 import kernel360.ckt.core.domain.entity.CustomerEntity;
 import kernel360.ckt.core.domain.enums.CustomerStatus;
@@ -28,6 +26,7 @@ import java.util.List;
 public class CustomerController {
 
     private final CustomerService customerService;
+    private final CustomerRentalQueryService customerRentalQueryService;
 
     @GetMapping
     public CommonResponse<CustomerListResponse> getAllCustomers(
@@ -76,5 +75,10 @@ public class CustomerController {
     public CommonResponse<CustomerKeywordListResponse> searchKeyword(CustomerKeywordRequest request) {
         final List<CustomerEntity> customers = customerService.searchKeyword(request.toCommand());
         return CommonResponse.success(CustomerKeywordListResponse.from(customers));
+    }
+
+    @GetMapping("/{id}/rentals")
+    public CommonResponse<RentalOverviewResponse> getCustomerRentalSummary(@PathVariable Long id) {
+        return CommonResponse.success(customerRentalQueryService.getRentalSummary(id));
     }
 }

--- a/admin/src/main/java/kernel360/ckt/admin/ui/dto/response/CurrentRentalResponse.java
+++ b/admin/src/main/java/kernel360/ckt/admin/ui/dto/response/CurrentRentalResponse.java
@@ -1,0 +1,14 @@
+package kernel360.ckt.admin.ui.dto.response;
+
+import lombok.Builder;
+
+import java.time.LocalDate;
+
+@Builder
+public record CurrentRentalResponse(
+    String vehicleName,
+    String licensePlate,
+    LocalDate startDate,
+    LocalDate endDate,
+    String status
+) {}

--- a/admin/src/main/java/kernel360/ckt/admin/ui/dto/response/RentalHistoryResponse.java
+++ b/admin/src/main/java/kernel360/ckt/admin/ui/dto/response/RentalHistoryResponse.java
@@ -1,0 +1,15 @@
+package kernel360.ckt.admin.ui.dto.response;
+
+import lombok.Builder;
+
+import java.time.LocalDate;
+
+@Builder
+public record RentalHistoryResponse(
+    String reservationId,
+    String vehicleName,
+    String licensePlate,
+    LocalDate startDate,
+    LocalDate endDate,
+    String status
+) {}

--- a/admin/src/main/java/kernel360/ckt/admin/ui/dto/response/RentalOverviewResponse.java
+++ b/admin/src/main/java/kernel360/ckt/admin/ui/dto/response/RentalOverviewResponse.java
@@ -1,0 +1,12 @@
+package kernel360.ckt.admin.ui.dto.response;
+
+import java.util.List;
+import lombok.Builder;
+
+@Builder
+public record RentalOverviewResponse(
+    int totalCount,
+    int activeCount,
+    CurrentRentalResponse currentRental,
+    List<RentalHistoryResponse> rentalHistory
+) {}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
<!-- ex) #이슈번호[, #이슈번호] -->

> #91 

## 📝 작업 내용
> ### 백엔드 작업 내용
> - `RentalOverviewResponse`, `CurrentRentalResponse`, `RentalHistoryResponse` DTO 생성
> - 고객별 대여 현황을 조회하는 서비스 로직 `CustomerRentalQueryService#getRentalSummary` 구현
> - `/api/v1/customers/{id}/rentals` API 엔드포인트 추가 (CustomerController)
> - `RentalRepository` 인터페이스에 다음 메서드 정의
>   - `findLatestRentalByCustomerIdAndStatus`
>   - `findAllByCustomerIdFetchVehicle`
>   - `countByCustomerId`
>   - `countByCustomerIdAndStatus`
> - `RentalRepositoryAdapter`, `RentalJpaRepository`에서 구현 및 쿼리 작성 (JOIN FETCH로 Lazy 문제 방지)
> - 포트(`RentalRepository`)에 JavaDoc 기반 주석 추가
> - 기존 잘못된 vehicle 조회 로직(`findById(companyId, vehicleId)`) → `findById(vehicleId, companyId)`로 수정
