### PR TITLE
feat: 고객 도메인에 company_id 및 delete_yn 필드 추가 및 로직 반영

### DIFF
--- a/admin/src/main/java/kernel360/ckt/admin/application/port/CustomerRepository.java
+++ b/admin/src/main/java/kernel360/ckt/admin/application/port/CustomerRepository.java
@@ -50,21 +50,6 @@ public interface CustomerRepository {
     Optional<CustomerEntity> findByLicenseNumber(String licenseNumber);
 
     /**
-     * 고객 ID로 고객을 삭제합니다.
-     *
-     * @param id 삭제할 고객 ID
-     */
-    void deleteById(Long id);
-
-    /**
-     * 고객 ID의 존재 여부를 확인합니다.
-     *
-     * @param id 고객 ID
-     * @return 존재하면 true, 아니면 false
-     */
-    boolean existsById(Long id);
-
-    /**
      * 전체 고객 수를 조회합니다.
      *
      * @return 전체 고객 수
@@ -86,4 +71,23 @@ public interface CustomerRepository {
      * @return
      */
     List<CustomerEntity> findByCustomerNameContainingOrPhoneNumberContaining(String customerNameKeyword, String phoneNumberKeyword);
+
+    /**
+     * ID 및 삭제 여부(deleteYn)를 기준으로 고객을 조회합니다.
+     *
+     * @param id        고객 ID
+     * @param deleteYn  삭제 여부 ('N' 또는 'Y')
+     * @return 조건에 맞는 고객 정보
+     */
+    Optional<CustomerEntity> findByIdAndDeleteYn(Long id, String deleteYn);
+
+    /**
+     * 고객 상태 및 삭제 여부(deleteYn)를 기준으로 페이징된 고객 목록을 조회합니다.
+     *
+     * @param status     고객 상태
+     * @param deleteYn   삭제 여부 ('N' 또는 'Y')
+     * @param pageable   페이징 정보
+     * @return 조건에 맞는 고객 페이지
+     */
+    Page<CustomerEntity> findAllByStatusAndDeleteYn(CustomerStatus status, String deleteYn, Pageable pageable);
 }

--- a/admin/src/main/java/kernel360/ckt/admin/application/service/CustomerService.java
+++ b/admin/src/main/java/kernel360/ckt/admin/application/service/CustomerService.java
@@ -72,9 +72,7 @@ public class CustomerService {
     }
 
     public CustomerEntity findById(Long id) {
-        log.info("고객 상세 조회 시도: id={}", id);
-
-        return customerRepository.findById(id)
+        return customerRepository.findByIdAndDeleteYn(id, "N")
             .orElseThrow(() -> new CustomException(CustomerErrorCode.CUSTOMER_NOT_FOUND));
     }
 
@@ -85,7 +83,7 @@ public class CustomerService {
         CustomerEntity customer = customerRepository.findById(id)
             .orElseThrow(() -> new CustomException(CustomerErrorCode.CUSTOMER_NOT_FOUND));
 
-        customerRepository.deleteById(id);
+        customer.markAsDeleted();
         log.info("고객 삭제 완료: id={}", id);
     }
 

--- a/admin/src/main/java/kernel360/ckt/admin/infra/CustomerRepositoryAdapter.java
+++ b/admin/src/main/java/kernel360/ckt/admin/infra/CustomerRepositoryAdapter.java
@@ -39,16 +39,6 @@ public class CustomerRepositoryAdapter implements CustomerRepository {
     }
 
     @Override
-    public void deleteById(Long id) {
-        customerJpaRepository.deleteById(id);
-    }
-
-    @Override
-    public boolean existsById(Long id) {
-        return customerJpaRepository.existsById(id);
-    }
-
-    @Override
     public long countTotal() {
         return customerJpaRepository.count();
     }
@@ -61,6 +51,16 @@ public class CustomerRepositoryAdapter implements CustomerRepository {
     @Override
     public List<CustomerEntity> findByCustomerNameContainingOrPhoneNumberContaining(String customerNameKeyword, String phoneNumberKeyword) {
         return customerJpaRepository.findByCustomerNameContainingOrPhoneNumberContaining(customerNameKeyword, phoneNumberKeyword);
+    }
+
+    @Override
+    public Optional<CustomerEntity> findByIdAndDeleteYn(Long id, String deleteYn) {
+        return customerJpaRepository.findByIdAndDeleteYn(id, deleteYn);
+    }
+
+    @Override
+    public Page<CustomerEntity> findAllByStatusAndDeleteYn(CustomerStatus status, String deleteYn, Pageable pageable) {
+        return customerJpaRepository.findAllByStatusAndDeleteYn(status, deleteYn, pageable);
     }
 
 }

--- a/admin/src/main/java/kernel360/ckt/admin/infra/jpa/CustomerJpaRepository.java
+++ b/admin/src/main/java/kernel360/ckt/admin/infra/jpa/CustomerJpaRepository.java
@@ -14,13 +14,14 @@ import java.util.Optional;
 
 public interface CustomerJpaRepository extends JpaRepository<CustomerEntity, Long> {
     @Query("""
-        SELECT c FROM CustomerEntity c
-        WHERE (:status IS NULL OR c.status = :status)
-          AND (
-            :keyword IS NULL
-            OR c.customerName LIKE %:keyword%
-            OR c.phoneNumber LIKE %:keyword%
-          )
+    SELECT c FROM CustomerEntity c
+    WHERE c.deleteYn = 'N'
+      AND (:status IS NULL OR c.status = :status)
+      AND (
+        :keyword IS NULL
+        OR c.customerName LIKE %:keyword%
+        OR c.phoneNumber LIKE %:keyword%
+      )
     """)
     Page<CustomerEntity> findAll(
         @Param("status") CustomerStatus status,
@@ -38,4 +39,8 @@ public interface CustomerJpaRepository extends JpaRepository<CustomerEntity, Lon
     long countByCustomerType(@Param("type") CustomerType type);
 
     List<CustomerEntity> findByCustomerNameContainingOrPhoneNumberContaining(String customerNameKeyword, String phoneNumberKeyword);
+
+    Optional<CustomerEntity> findByIdAndDeleteYn(Long id, String deleteYn);
+
+    Page<CustomerEntity> findAllByStatusAndDeleteYn(CustomerStatus status, String deleteYn, Pageable pageable);
 }

--- a/core/src/main/java/kernel360/ckt/core/domain/entity/CustomerEntity.java
+++ b/core/src/main/java/kernel360/ckt/core/domain/entity/CustomerEntity.java
@@ -43,7 +43,7 @@ public class CustomerEntity extends BaseTimeEntity {
     @JoinColumn(name = "company_id", nullable = false)
     private CompanyEntity company;
 
-    @Column(name = "delete_yn", nullable = false)
+    @Column(name = "delete_yn", nullable = false, length = 1, columnDefinition = "CHAR(1)")
     private String deleteYn = "N";
 
     public CustomerEntity(CustomerType customerType,

--- a/core/src/main/java/kernel360/ckt/core/domain/entity/CustomerEntity.java
+++ b/core/src/main/java/kernel360/ckt/core/domain/entity/CustomerEntity.java
@@ -39,6 +39,13 @@ public class CustomerEntity extends BaseTimeEntity {
     @Column(nullable = false)
     private CustomerStatus status;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "company_id", nullable = false)
+    private CompanyEntity company;
+
+    @Column(name = "delete_yn", nullable = false)
+    private String deleteYn = "N";
+
     public CustomerEntity(CustomerType customerType,
                           String email,
                           String customerName,
@@ -109,8 +116,8 @@ public class CustomerEntity extends BaseTimeEntity {
         this.birthday = birthday;
     }
 
-    public void updateStatus(CustomerStatus status) {
-        this.status = status;
+    public void markAsDeleted() {
+        this.deleteYn = "Y";
     }
 
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
<!-- ex) #이슈번호[, #이슈번호] -->

> #95 


## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 설명해 주세요. (이미지 첨부 가능) -->

> - CustomerEntity에 `company` 연관 관계(@ManyToOne) 및 `deleteYn` 필드 추가
> - CustomerService에 논리 삭제 처리 메서드(markAsDeleted) 적용
> - CustomerRepository에 `findByIdAndDeleteYn`, `findAllByStatusAndDeleteYn` 메서드 정의
> - CustomerJpaRepository에 `deleteYn` 기반 페이징 목록 쿼리 추가
> - CustomerRepositoryAdapter에 위 메서드 구현 로직 반영
>
> 회사별 고객 관리 기능과 논리 삭제 기반의 이력 관리 기능을 위한 구조 개선입니다.

## 👀 리뷰어 가이드라인
<!-- 리뷰어가 중점적으로 확인해야 할 사항을 작성해 주세요. -->

> - deleteYn 필드가 조회/삭제/목록 쿼리에 잘 반영되었는지
> - company 연관 관계가 null-safe하게 적용되었는지
> - CustomerService의 delete 로직이 실제로 물리 삭제가 아닌 논리 삭제로 잘 작동하는지
