### PR TITLE
refactor: 통계 조회 시 rental_id 없는 운행 로그도 포함되도록 쿼리 및 조인 구조 개선

### DIFF
--- a/admin/src/main/java/kernel360/ckt/admin/application/service/LogSummaryService.java
+++ b/admin/src/main/java/kernel360/ckt/admin/application/service/LogSummaryService.java
@@ -23,11 +23,10 @@ public class LogSummaryService {
     public List<VehicleLogSummaryResponse> getVehicleLogSummary(
         LocalDateTime from,
         LocalDateTime to,
-        String registrationNumber,
-        String driverName
+        String registrationNumber
     ) {
         List<VehicleLogSummaryProjection> projections =
-            routeLogRepository.findVehicleLogSummaryBetween(from, to, registrationNumber, driverName);
+            routeLogRepository.findVehicleLogSummaryBetween(from, to, registrationNumber);
 
         return projections.stream()
             .map(p -> new VehicleLogSummaryResponse(

--- a/admin/src/main/java/kernel360/ckt/admin/infra/basic/RouteLogRepository.java
+++ b/admin/src/main/java/kernel360/ckt/admin/infra/basic/RouteLogRepository.java
@@ -29,13 +29,13 @@ public interface RouteLogRepository extends Repository<RouteEntity, Long> {
             ) AS averageDrivingTime
         FROM route r
         LEFT JOIN driving_log dl ON r.driving_log_id = dl.id
+        LEFT JOIN vehicle v ON dl.vehicle_id = v.id
+        LEFT JOIN company c ON v.company_id = c.id
         LEFT JOIN rental rent ON dl.rental_id = rent.id
-        LEFT JOIN vehicle v ON rent.vehicle_id = v.id
-        LEFT JOIN company c ON rent.company_id = c.id
         LEFT JOIN customer cu ON rent.customer_id = cu.id
         WHERE r.start_at BETWEEN :startDate AND :endDate
           AND (:registrationNumber IS NULL OR :registrationNumber = '' OR v.registration_number = :registrationNumber)
-          AND (:driverName IS NULL OR :driverName = '' OR cu.customer_name LIKE CONCAT('%', :driverName, '%'))
+          AND (:driverName IS NULL OR :driverName = '' OR (cu.customer_name IS NOT NULL AND cu.customer_name LIKE CONCAT('%', :driverName, '%')))
         GROUP BY v.registration_number, c.name
         """,
         nativeQuery = true
@@ -62,11 +62,10 @@ public interface RouteLogRepository extends Repository<RouteEntity, Long> {
             ) AS totalDrivingTime,
             COUNT(DISTINCT DATE(r.start_at)) AS drivingDays
         FROM route r
-        JOIN driving_log dl ON r.driving_log_id = dl.id
-        JOIN rental rent ON dl.rental_id = rent.id
-        JOIN vehicle v ON rent.vehicle_id = v.id
+        LEFT JOIN driving_log dl ON r.driving_log_id = dl.id
+        LEFT JOIN vehicle v ON dl.vehicle_id = v.id
         WHERE r.start_at BETWEEN :startDate AND :endDate
-          AND v.registration_number = :registrationNumber
+          AND (:registrationNumber IS NULL OR :registrationNumber = '' OR v.registration_number = :registrationNumber)
         GROUP BY YEARWEEK(r.start_at, 1)
         ORDER BY startDate
         """,
@@ -77,8 +76,10 @@ public interface RouteLogRepository extends Repository<RouteEntity, Long> {
         @Param("endDate") LocalDateTime endDate,
         @Param("registrationNumber") String registrationNumber
     );
+
     // 일별 운행 통계
-    @Query(value = """
+    @Query(
+    value = """
     SELECT
         DATE(r.start_at) AS drivingDate,
         SUM(r.total_distance) AS totalDistance,
@@ -88,11 +89,10 @@ public interface RouteLogRepository extends Repository<RouteEntity, Long> {
             LPAD(MOD(SUM(TIMESTAMPDIFF(SECOND, r.start_at, r.end_at)), 60), 2, '0')
         ) AS totalDrivingTime
     FROM route r
-    JOIN driving_log dl ON r.driving_log_id = dl.id
-    JOIN rental rent ON dl.rental_id = rent.id
-    JOIN vehicle v ON rent.vehicle_id = v.id
+    LEFT JOIN driving_log dl ON r.driving_log_id = dl.id
+    LEFT JOIN vehicle v ON dl.vehicle_id = v.id
     WHERE r.start_at BETWEEN :startDate AND :endDate
-      AND v.registration_number = :registrationNumber
+      AND (:registrationNumber IS NULL OR :registrationNumber = '' OR v.registration_number = :registrationNumber)
     GROUP BY DATE(r.start_at)
     ORDER BY drivingDate
 """, nativeQuery = true)

--- a/admin/src/main/java/kernel360/ckt/admin/infra/basic/RouteLogRepository.java
+++ b/admin/src/main/java/kernel360/ckt/admin/infra/basic/RouteLogRepository.java
@@ -31,11 +31,8 @@ public interface RouteLogRepository extends Repository<RouteEntity, Long> {
         LEFT JOIN driving_log dl ON r.driving_log_id = dl.id
         LEFT JOIN vehicle v ON dl.vehicle_id = v.id
         LEFT JOIN company c ON v.company_id = c.id
-        LEFT JOIN rental rent ON dl.rental_id = rent.id
-        LEFT JOIN customer cu ON rent.customer_id = cu.id
         WHERE r.start_at BETWEEN :startDate AND :endDate
           AND (:registrationNumber IS NULL OR :registrationNumber = '' OR v.registration_number = :registrationNumber)
-          AND (:driverName IS NULL OR :driverName = '' OR (cu.customer_name IS NOT NULL AND cu.customer_name LIKE CONCAT('%', :driverName, '%')))
         GROUP BY v.registration_number, c.name
         """,
         nativeQuery = true
@@ -43,8 +40,7 @@ public interface RouteLogRepository extends Repository<RouteEntity, Long> {
     List<VehicleLogSummaryProjection> findVehicleLogSummaryBetween(
         @Param("startDate") LocalDateTime startDate,
         @Param("endDate") LocalDateTime endDate,
-        @Param("registrationNumber") String registrationNumber,
-        @Param("driverName") String driverName
+        @Param("registrationNumber") String registrationNumber
     );
 
     // 주간 운행 통계
@@ -101,5 +97,4 @@ public interface RouteLogRepository extends Repository<RouteEntity, Long> {
         @Param("endDate") LocalDateTime endDate,
         @Param("registrationNumber") String registrationNumber
     );
-
 }

--- a/admin/src/main/java/kernel360/ckt/admin/ui/LogSummaryController.java
+++ b/admin/src/main/java/kernel360/ckt/admin/ui/LogSummaryController.java
@@ -28,10 +28,9 @@ public class LogSummaryController {
     public List<VehicleLogSummaryResponse> getSummary(
         @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime from,
         @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime to,
-        @RequestParam(required = false) String registrationNumber,
-        @RequestParam(required = false) String driverName
+        @RequestParam(required = false) String registrationNumber
     ) {
-        return logSummaryService.getVehicleLogSummary(from, to, registrationNumber, driverName);
+        return logSummaryService.getVehicleLogSummary(from, to, registrationNumber);
     }
 
     @GetMapping("/weekly")


### PR DESCRIPTION
## #️⃣ 연관된 이슈
<!-- ex) #이슈번호[, #이슈번호] -->

> #99 

## 📝 작업 내용

1. **company 조인 대상 변경**
   - 기존: `rent.company_id` 기준 조인
   - 변경: `vehicle.company_id` 기준으로 조인
   - 목적: `rental_id`가 NULL인 운행 로그도 회사 정보가 조회되도록 처리

2. **NULL rental_id 포함 보장**
   - 모든 통계 쿼리에서 `LEFT JOIN` 구조 유지
   - `rental_id`가 없어도 데이터가 필터링되지 않도록 조건 수정

3. **불필요한 운전자명 필터 제거**
   - 프론트에서 운전자 검색 기능 제거됨에 따라, `driverName` 파라미터 및 관련 쿼리 필터 제거

## 👀 리뷰어 가이드라인
- `RouteLogRepository`의 쿼리 변경으로 인해 기존 로직이 누락되거나 잘못 포함되는 경우가 없는지 확인 부탁드립니다.
- `company` 조인 변경이 전체 통계 흐름에 미치는 영향 점검
