### PR TITLE
fix: 예약 관리 사용자 및 차량 도메인 변경 및 날짜 포매팅 변경에 따른 수정

### DIFF
--- a/admin/src/main/java/kernel360/ckt/admin/application/port/CustomerRepository.java
+++ b/admin/src/main/java/kernel360/ckt/admin/application/port/CustomerRepository.java
@@ -66,11 +66,12 @@ public interface CustomerRepository {
 
     /**
      * Keyword에 맞는 고객을 조회합니다.
-     * @param customerNameKeyword
-     * @param phoneNumberKeyword
-     * @return
+     * @param companyId 회사의 ID
+     * @param customerNameKeyword 키워드 - 고객명
+     * @param phoneNumberKeyword 키워드 - 휴대폰 번호
+     * @return 조건에 맞은 고객 정보
      */
-    List<CustomerEntity> findByCustomerNameContainingOrPhoneNumberContaining(String customerNameKeyword, String phoneNumberKeyword);
+    List<CustomerEntity> search(Long companyId, String customerNameKeyword, String phoneNumberKeyword);
 
     /**
      * ID 및 삭제 여부(deleteYn)를 기준으로 고객을 조회합니다.

--- a/admin/src/main/java/kernel360/ckt/admin/application/service/CustomerService.java
+++ b/admin/src/main/java/kernel360/ckt/admin/application/service/CustomerService.java
@@ -101,7 +101,7 @@ public class CustomerService {
     }
 
     public List<CustomerEntity> searchKeyword(CustomerKeywordCommand command) {
-        return customerRepository.findByCustomerNameContainingOrPhoneNumberContaining(command.getKeyword(), command.getKeyword());
+        return customerRepository.search(command.getCompanyId(), command.getKeyword(), command.getKeyword());
     }
 
 }

--- a/admin/src/main/java/kernel360/ckt/admin/application/service/command/CustomerKeywordCommand.java
+++ b/admin/src/main/java/kernel360/ckt/admin/application/service/command/CustomerKeywordCommand.java
@@ -6,5 +6,6 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public class CustomerKeywordCommand {
+    private final Long companyId;
     private final String keyword;
 }

--- a/admin/src/main/java/kernel360/ckt/admin/infra/CustomerRepositoryAdapter.java
+++ b/admin/src/main/java/kernel360/ckt/admin/infra/CustomerRepositoryAdapter.java
@@ -49,8 +49,8 @@ public class CustomerRepositoryAdapter implements CustomerRepository {
     }
 
     @Override
-    public List<CustomerEntity> findByCustomerNameContainingOrPhoneNumberContaining(String customerNameKeyword, String phoneNumberKeyword) {
-        return customerJpaRepository.findByCustomerNameContainingOrPhoneNumberContaining(customerNameKeyword, phoneNumberKeyword);
+    public List<CustomerEntity> search(Long companyId, String customerNameKeyword, String phoneNumberKeyword) {
+        return customerJpaRepository.findByDeleteYnAndCompanyIdAndCustomerNameStartingWithOrPhoneNumberStartingWith("N", companyId, customerNameKeyword, phoneNumberKeyword);
     }
 
     @Override

--- a/admin/src/main/java/kernel360/ckt/admin/infra/jpa/CustomerJpaRepository.java
+++ b/admin/src/main/java/kernel360/ckt/admin/infra/jpa/CustomerJpaRepository.java
@@ -38,7 +38,7 @@ public interface CustomerJpaRepository extends JpaRepository<CustomerEntity, Lon
     @Query("SELECT COUNT(c) FROM CustomerEntity c WHERE c.customerType = :type")
     long countByCustomerType(@Param("type") CustomerType type);
 
-    List<CustomerEntity> findByCustomerNameContainingOrPhoneNumberContaining(String customerNameKeyword, String phoneNumberKeyword);
+    List<CustomerEntity> findByDeleteYnAndCompanyIdAndCustomerNameStartingWithOrPhoneNumberStartingWith(String deleteYn, Long companyId, String customerNameKeyword, String phoneNumberKeyword);
 
     Optional<CustomerEntity> findByIdAndDeleteYn(Long id, String deleteYn);
 

--- a/admin/src/main/java/kernel360/ckt/admin/infra/jpa/VehicleJpaRepository.java
+++ b/admin/src/main/java/kernel360/ckt/admin/infra/jpa/VehicleJpaRepository.java
@@ -31,14 +31,14 @@ public interface VehicleJpaRepository extends JpaRepository<VehicleEntity, Long>
         SELECT v
         FROM VehicleEntity v
         LEFT JOIN RentalEntity r ON v.id = r.vehicle.id
-            AND r.status = 'RENTED'
+            AND r.status IN ('PENDING', 'RENTED')
             AND r.pickupAt <= :returnAt
             AND r.returnAt >= :pickupAt
         WHERE v.deleteYn = false
         AND (v.company.id = :companyId)
         AND
-            (LOWER(v.registrationNumber) LIKE LOWER(CONCAT('%', :keyword, '%')) OR
-             LOWER(v.modelName) LIKE LOWER(CONCAT('%', :keyword, '%')))
+            (LOWER(v.registrationNumber) LIKE LOWER(CONCAT(:keyword, '%')) OR
+             LOWER(v.modelName) LIKE LOWER(CONCAT(:keyword, '%')))
         AND r.id IS NULL
     """)
     List<VehicleEntity> searchAvailableVehiclesByKeyword(

--- a/admin/src/main/java/kernel360/ckt/admin/ui/CustomerController.java
+++ b/admin/src/main/java/kernel360/ckt/admin/ui/CustomerController.java
@@ -24,6 +24,7 @@ import java.util.List;
 @RestController
 @RequestMapping("/api/v1/customers")
 public class CustomerController {
+    private static final String X_USER_ID_HEADER = "X-User-Id";
 
     private final CustomerService customerService;
     private final CustomerRentalQueryService customerRentalQueryService;
@@ -72,8 +73,8 @@ public class CustomerController {
     }
 
     @GetMapping("/search")
-    public CommonResponse<CustomerKeywordListResponse> searchKeyword(CustomerKeywordRequest request) {
-        final List<CustomerEntity> customers = customerService.searchKeyword(request.toCommand());
+    public CommonResponse<CustomerKeywordListResponse> searchKeyword(@RequestHeader(X_USER_ID_HEADER) Long companyId, CustomerKeywordRequest request) {
+        final List<CustomerEntity> customers = customerService.searchKeyword(request.toCommand(companyId));
         return CommonResponse.success(CustomerKeywordListResponse.from(customers));
     }
 

--- a/admin/src/main/java/kernel360/ckt/admin/ui/VehicleController.java
+++ b/admin/src/main/java/kernel360/ckt/admin/ui/VehicleController.java
@@ -90,7 +90,7 @@ public class VehicleController {
     @GetMapping("/search")
     public CommonResponse<VehicleKeywordListResponse> searchKeyword(
         @RequestHeader(X_USER_ID_HEADER) Long companyId,
-        VehicleKeywordRequest request
+        @Valid VehicleKeywordRequest request
     ) {
         final List<VehicleEntity> vehicles = vehicleService.searchKeyword(request.toCommand(companyId));
         return CommonResponse.success(VehicleKeywordListResponse.from(vehicles));

--- a/admin/src/main/java/kernel360/ckt/admin/ui/dto/request/CustomerKeywordRequest.java
+++ b/admin/src/main/java/kernel360/ckt/admin/ui/dto/request/CustomerKeywordRequest.java
@@ -5,8 +5,9 @@ import kernel360.ckt.admin.application.service.command.CustomerKeywordCommand;
 public record CustomerKeywordRequest(
     String keyword
 ) {
-    public CustomerKeywordCommand toCommand() {
+    public CustomerKeywordCommand toCommand(Long companyId) {
         return new CustomerKeywordCommand(
+            companyId,
             this.keyword
         );
     }

--- a/admin/src/main/java/kernel360/ckt/admin/ui/dto/request/RentalCreateRequest.java
+++ b/admin/src/main/java/kernel360/ckt/admin/ui/dto/request/RentalCreateRequest.java
@@ -1,5 +1,6 @@
 package kernel360.ckt.admin.ui.dto.request;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import jakarta.validation.constraints.FutureOrPresent;
 import jakarta.validation.constraints.NotNull;
 import java.time.LocalDateTime;
@@ -14,10 +15,12 @@ public record RentalCreateRequest(
 
     @NotNull(message = "픽업 시간은 필수입니다.")
     @FutureOrPresent(message = "픽업 시간은 현재보다 미래여야 합니다.")
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
     LocalDateTime pickupAt,
 
     @NotNull(message = "반납 시간은 필수입니다.")
     @FutureOrPresent(message = "반납 시간은 현재보다 미래여야 합니다.")
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
     LocalDateTime returnAt,
 
     String memo

--- a/admin/src/main/java/kernel360/ckt/admin/ui/dto/request/RentalListRequest.java
+++ b/admin/src/main/java/kernel360/ckt/admin/ui/dto/request/RentalListRequest.java
@@ -9,10 +9,10 @@ public record RentalListRequest(
     RentalStatus status,
     String keyword,
 
-    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    @DateTimeFormat(pattern = "yyyy-MM-dd HH:mm:ss")
     LocalDateTime startAt,
 
-    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    @DateTimeFormat(pattern = "yyyy-MM-dd HH:mm:ss")
     LocalDateTime endAt
 ) {
     public RentalListCommand toCommand(Long companyId) {

--- a/admin/src/main/java/kernel360/ckt/admin/ui/dto/request/RentalUpdateRequest.java
+++ b/admin/src/main/java/kernel360/ckt/admin/ui/dto/request/RentalUpdateRequest.java
@@ -1,10 +1,9 @@
 package kernel360.ckt.admin.ui.dto.request;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import jakarta.validation.constraints.FutureOrPresent;
 import jakarta.validation.constraints.NotNull;
 import kernel360.ckt.admin.application.service.command.RentalUpdateCommand;
-import kernel360.ckt.admin.application.service.command.RentalUpdateStatusCommand;
-import kernel360.ckt.core.domain.enums.RentalStatus;
 
 import java.time.LocalDateTime;
 
@@ -17,10 +16,12 @@ public record RentalUpdateRequest(
 
     @NotNull(message = "픽업 시간은 필수입니다.")
     @FutureOrPresent(message = "픽업 시간은 현재보다 미래여야 합니다.")
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
     LocalDateTime pickupAt,
 
     @NotNull(message = "반납 시간은 필수입니다.")
     @FutureOrPresent(message = "반납 시간은 현재보다 미래여야 합니다.")
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
     LocalDateTime returnAt,
 
     String memo

--- a/admin/src/main/java/kernel360/ckt/admin/ui/dto/request/VehicleKeywordRequest.java
+++ b/admin/src/main/java/kernel360/ckt/admin/ui/dto/request/VehicleKeywordRequest.java
@@ -12,12 +12,12 @@ public record VehicleKeywordRequest(
 
     @NotNull(message = "픽업 시간은 필수입니다.")
     @FutureOrPresent(message = "픽업 시간은 현재보다 미래여야 합니다.")
-    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    @DateTimeFormat(pattern = "yyyy-MM-dd HH:mm:ss")
     LocalDateTime pickupAt,
 
     @NotNull(message = "반납 시간은 필수입니다.")
     @FutureOrPresent(message = "반납 시간은 현재보다 미래여야 합니다.")
-    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    @DateTimeFormat(pattern = "yyyy-MM-dd HH:mm:ss")
     LocalDateTime returnAt
 ) {
     public VehicleKeywordRequest {

--- a/admin/src/main/java/kernel360/ckt/admin/ui/dto/response/CustomerKeywordResponse.java
+++ b/admin/src/main/java/kernel360/ckt/admin/ui/dto/response/CustomerKeywordResponse.java
@@ -5,13 +5,15 @@ import kernel360.ckt.core.domain.entity.CustomerEntity;
 public record CustomerKeywordResponse(
     Long id,
     String customerName,
-    String phoneNumber
+    String phoneNumber,
+    String email
 ){
     public static CustomerKeywordResponse from(CustomerEntity customerEntity) {
         return new CustomerKeywordResponse(
             customerEntity.getId(),
             customerEntity.getCustomerName(),
-            customerEntity.getPhoneNumber()
+            customerEntity.getPhoneNumber(),
+            customerEntity.getEmail()
         );
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
<!-- ex) #이슈번호[, #이슈번호] -->

- #100 


## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 설명해 주세요. (이미지 첨부 가능) -->

1. 고객 키워드 검색 (예약 관리 페이지)
    - 기존 : 모든 회사 및 삭제된 고객도 모두 검색
    - 변경 : companyId 와 deleteYn 'N' 조건절 추가로 해당하는 고객만 검색 되도록 변경
2. 차량 키워드 검색 (예약 관리 페이지)
    - 기존 : 400 에러 (valid)
    - 변경 : api 와 front 간의 LocalDateTime 형태를 `@DateTimeFormat` 와 `@JsonFormat`을 통해 일치
3. 예약 관리
    - 기존 : 400 에러 (valid)
    - 변경 : api 와 front 간의 LocalDateTime 형태를 `@DateTimeFormat` 와 `@JsonFormat`을 통해 일치

## 👀 리뷰어 가이드라인
<!-- 리뷰어가 중점적으로 확인해야 할 사항을 작성해 주세요. -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

- 예약 등록 및 수정 시 검색 영역에 대해 더 고려해야하는 필터링이 있는지 확인 부탁드립니다.
- LocalDateTime을 일치시키는 방향에서 의견이 있으실지 확인 부탁드립니다.
