### PR TITLE
feat: 운행일지 상세페이지에 경로 찍기

### DIFF
--- a/admin/src/main/java/kernel360/ckt/admin/application/port/VehicleTraceLogRepository.java
+++ b/admin/src/main/java/kernel360/ckt/admin/application/port/VehicleTraceLogRepository.java
@@ -1,0 +1,9 @@
+package kernel360.ckt.admin.application.port;
+
+import kernel360.ckt.core.domain.entity.VehicleTraceLogEntity;
+
+import java.util.List;
+
+public interface VehicleTraceLogRepository {
+    List<VehicleTraceLogEntity> findByRouteId(Long routeId);
+}

--- a/admin/src/main/java/kernel360/ckt/admin/infra/TraceLogRepositoryAdapter.java
+++ b/admin/src/main/java/kernel360/ckt/admin/infra/TraceLogRepositoryAdapter.java
@@ -1,0 +1,20 @@
+package kernel360.ckt.admin.infra;
+
+import kernel360.ckt.admin.application.port.VehicleTraceLogRepository;
+import kernel360.ckt.admin.infra.jpa.VehicleTraceLogJpaRepository;
+import kernel360.ckt.core.domain.entity.VehicleTraceLogEntity;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Repository
+public class TraceLogRepositoryAdapter implements VehicleTraceLogRepository {
+    private final VehicleTraceLogJpaRepository vehicleTraceLogJpaRepository;
+
+    @Override
+    public List<VehicleTraceLogEntity> findByRouteId(Long routeId) {
+        return vehicleTraceLogJpaRepository.findByRouteId(routeId);
+    }
+}

--- a/admin/src/main/java/kernel360/ckt/admin/infra/jpa/VehicleTraceLogJpaRepository.java
+++ b/admin/src/main/java/kernel360/ckt/admin/infra/jpa/VehicleTraceLogJpaRepository.java
@@ -1,0 +1,10 @@
+package kernel360.ckt.admin.infra.jpa;
+
+import kernel360.ckt.core.domain.entity.VehicleTraceLogEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface VehicleTraceLogJpaRepository extends JpaRepository<VehicleTraceLogEntity, Long> {
+    List<VehicleTraceLogEntity> findByRouteId(Long routeId);
+}

--- a/admin/src/main/java/kernel360/ckt/admin/ui/dto/response/DrivingLogDetailResponse.java
+++ b/admin/src/main/java/kernel360/ckt/admin/ui/dto/response/DrivingLogDetailResponse.java
@@ -1,18 +1,24 @@
 package kernel360.ckt.admin.ui.dto.response;
 
+import kernel360.ckt.core.domain.dto.CycleInformation;
 import kernel360.ckt.core.domain.entity.DrivingLogEntity;
 import kernel360.ckt.core.domain.entity.RouteEntity;
 
 import java.util.List;
+import java.util.Map;
 
 public record DrivingLogDetailResponse(
     DrivingLogResponse drivingLogResponse,
     List<RouteInfoResponse> routes
 ) {
-    public static DrivingLogDetailResponse from(DrivingLogEntity drivingLogEntity, List<RouteEntity> routeEntities) {
+    public static DrivingLogDetailResponse from(DrivingLogEntity drivingLogEntity, List<RouteEntity> routeEntities, Map<Long, List<CycleInformation>> routeIdToTraceLogsMap) {
         DrivingLogResponse drivingLogResponse = DrivingLogResponse.of(drivingLogEntity, routeEntities);
+
         List<RouteInfoResponse> routes = routeEntities.stream()
-            .map(RouteInfoResponse::from)
+            .map(route -> {
+                List<CycleInformation> traceLogs = routeIdToTraceLogsMap.getOrDefault(route.getId(), List.of());
+                return RouteInfoResponse.from(route, traceLogs);
+            })
             .toList();
 
         return new DrivingLogDetailResponse(drivingLogResponse, routes);

--- a/admin/src/main/java/kernel360/ckt/admin/ui/dto/response/DrivingLogResponse.java
+++ b/admin/src/main/java/kernel360/ckt/admin/ui/dto/response/DrivingLogResponse.java
@@ -8,6 +8,7 @@ import kernel360.ckt.core.domain.enums.DrivingType;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
 public record DrivingLogResponse(
@@ -40,15 +41,27 @@ public record DrivingLogResponse(
             .map(CustomerEntity::getCustomerName)
             .orElse(null);
 
+        LocalDateTime startAt = routes.stream()
+            .map(RouteEntity::getStartAt)
+            .filter(Objects::nonNull)
+            .min(LocalDateTime::compareTo)
+            .orElse(null);
+
+        LocalDateTime endAt = routes.stream()
+            .map(RouteEntity::getEndAt)
+            .filter(Objects::nonNull)
+            .max(LocalDateTime::compareTo)
+            .orElse(null);
+
         return new DrivingLogResponse(
             drivingLogEntity.getId(),
             drivingLogEntity.getVehicle().getModelName(),
             drivingLogEntity.getVehicle().getRegistrationNumber(),
-            drivingLogEntity.getRental().getPickupAt(),
-            drivingLogEntity.getRental().getReturnAt(),
+            startAt,
+            endAt,
             startOdometer,
             endOdometer,
-            endOdometer-startOdometer,
+            endOdometer - startOdometer,
             customerName,
             drivingLogEntity.getType(),
             drivingLogEntity.getType().getValue(),

--- a/admin/src/main/java/kernel360/ckt/admin/ui/dto/response/RouteInfoResponse.java
+++ b/admin/src/main/java/kernel360/ckt/admin/ui/dto/response/RouteInfoResponse.java
@@ -1,8 +1,11 @@
 package kernel360.ckt.admin.ui.dto.response;
 
+import kernel360.ckt.core.domain.dto.CycleInformation;
+import kernel360.ckt.core.domain.dto.LatLng;
 import kernel360.ckt.core.domain.entity.RouteEntity;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 public record RouteInfoResponse(
     double startLat,
@@ -10,16 +13,22 @@ public record RouteInfoResponse(
     double endLat,
     double endLon,
     LocalDateTime startAt,
-    LocalDateTime endAt
+    LocalDateTime endAt,
+    List<LatLng> traceLogs
 ) {
-    public static RouteInfoResponse from(RouteEntity routeEntity) {
+    public static RouteInfoResponse from(RouteEntity routeEntity, List<CycleInformation> traceLogs) {
+        List<LatLng> latLngLogs = traceLogs.stream()
+            .map(ci -> new LatLng(ci.lat(), ci.lon()))
+            .toList();
+
         return new RouteInfoResponse(
             routeEntity.getStartLat(),
             routeEntity.getStartLon(),
             routeEntity.getEndLat(),
             routeEntity.getEndLon(),
             routeEntity.getStartAt(),
-            routeEntity.getEndAt()
+            routeEntity.getEndAt(),
+            latLngLogs
         );
     }
 }

--- a/core/src/main/java/kernel360/ckt/core/domain/dto/LatLng.java
+++ b/core/src/main/java/kernel360/ckt/core/domain/dto/LatLng.java
@@ -1,0 +1,7 @@
+package kernel360.ckt.core.domain.dto;
+
+public record LatLng(
+    String lat,
+    String lon
+) {
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#103 


## 📝 작업 내용
route 테이블에서 driving log id로 필터링 -> trace log 테이블에서 route id로 필터링한 후, trace log 테이블에서 위도, 경도만 추출했습니다.
그 후, 각 route id에 대해 해당하는 모든 trace 로그들이 병합된 결과가 담긴 Map을 생성하여 리턴해줬습니다.


## 👀 리뷰어 가이드라인
