### PR TITLE
fix: CustomerEntity의 company_id 필드 nullable 설정 수정

### DIFF
--- a/core/src/main/java/kernel360/ckt/core/domain/entity/CustomerEntity.java
+++ b/core/src/main/java/kernel360/ckt/core/domain/entity/CustomerEntity.java
@@ -40,7 +40,7 @@ public class CustomerEntity extends BaseTimeEntity {
     private CustomerStatus status;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "company_id", nullable = false)
+    @JoinColumn(name = "company_id")
     private CompanyEntity company;
 
     @Column(name = "delete_yn", nullable = false, length = 1, columnDefinition = "CHAR(1)")


### PR DESCRIPTION
## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 설명해 주세요. (이미지 첨부 가능) -->

> - @JoinColumn(name = "company_id")에서 nullable=false 제거
> - 회사 정보(company_id)가 없는 고객도 저장 가능하도록 설정 변경


