### PR TITLE
feat: 고객 생성/조회/통계 API에 회사 및 유형 기반 필터링 기능 추가

### DIFF
--- a/admin/src/main/java/kernel360/ckt/admin/application/port/CustomerRepository.java
+++ b/admin/src/main/java/kernel360/ckt/admin/application/port/CustomerRepository.java
@@ -31,7 +31,7 @@ public interface CustomerRepository {
      * @param pageable 페이징 정보
      * @return 조건에 맞는 고객 목록
      */
-    Page<CustomerEntity> findAll(Long companyId, CustomerStatus status, String keyword, Pageable pageable);
+    Page<CustomerEntity> findAll(Long companyId, CustomerType type, CustomerStatus status, String keyword, Pageable pageable);
 
     /**
      * 고객 ID로 고객을 조회합니다.

--- a/admin/src/main/java/kernel360/ckt/admin/application/port/CustomerRepository.java
+++ b/admin/src/main/java/kernel360/ckt/admin/application/port/CustomerRepository.java
@@ -68,19 +68,21 @@ public interface CustomerRepository {
     Optional<CustomerEntity> findByIdAndDeleteYn(Long id, String deleteYn);
 
     /**
-     * 회사 ID별 전체 고객 수를 조회합니다.
+     * 회사 ID 및 삭제 여부 기준으로 전체 고객 수를 조회합니다.
      *
      * @param companyId 회사의 ID
-     * @return 해당 회사의 전체 고객 수
+     * @param deleteYn 삭제 여부 ('N' 또는 'Y')
+     * @return 해당 조건의 고객 수
      */
-    long countTotalByCompanyId(Long companyId);
+    long countTotalByCompanyIdAndDeleteYn(Long companyId, String deleteYn);
 
     /**
-     * 회사 ID 및 고객 유형별 고객 수를 조회합니다.
+     * 회사 ID, 고객 유형, 삭제 여부 기준으로 고객 수를 조회합니다.
      *
-     * @param type 고객 유형 ("INDIVIDUAL" 또는 "CORPORATE")
+     * @param type 고객 유형
      * @param companyId 회사의 ID
-     * @return 해당 회사 및 유형의 고객 수
+     * @param deleteYn 삭제 여부 ('N' 또는 'Y')
+     * @return 조건에 맞는 고객 수
      */
-    long countByTypeAndCompanyId(CustomerType type, Long companyId);
+    long countByTypeAndCompanyIdAndDeleteYn(CustomerType type, Long companyId, String deleteYn);
 }

--- a/admin/src/main/java/kernel360/ckt/admin/application/port/CustomerRepository.java
+++ b/admin/src/main/java/kernel360/ckt/admin/application/port/CustomerRepository.java
@@ -31,7 +31,7 @@ public interface CustomerRepository {
      * @param pageable 페이징 정보
      * @return 조건에 맞는 고객 목록
      */
-    Page<CustomerEntity> findAll(CustomerStatus status, String keyword, Pageable pageable);
+    Page<CustomerEntity> findAll(Long companyId, CustomerStatus status, String keyword, Pageable pageable);
 
     /**
      * 고객 ID로 고객을 조회합니다.
@@ -48,21 +48,6 @@ public interface CustomerRepository {
      * @return 존재할 경우 고객 엔티티, 존재하지 않을 경우 빈 Optional 객체
      */
     Optional<CustomerEntity> findByLicenseNumber(String licenseNumber);
-
-    /**
-     * 전체 고객 수를 조회합니다.
-     *
-     * @return 전체 고객 수
-     */
-    long countTotal();
-
-    /**
-     * 고객 유형별(INIDIVIDUAL 또는 CORPORATE) 고객 수를 조회합니다.
-     *
-     * @param type 고객 유형 ("INDIVIDUAL" 또는 "CORPORATE")
-     * @return 해당 유형의 고객 수
-     */
-    long countByType(CustomerType type);
 
     /**
      * Keyword에 맞는 고객을 조회합니다.
@@ -83,12 +68,19 @@ public interface CustomerRepository {
     Optional<CustomerEntity> findByIdAndDeleteYn(Long id, String deleteYn);
 
     /**
-     * 고객 상태 및 삭제 여부(deleteYn)를 기준으로 페이징된 고객 목록을 조회합니다.
+     * 회사 ID별 전체 고객 수를 조회합니다.
      *
-     * @param status     고객 상태
-     * @param deleteYn   삭제 여부 ('N' 또는 'Y')
-     * @param pageable   페이징 정보
-     * @return 조건에 맞는 고객 페이지
+     * @param companyId 회사의 ID
+     * @return 해당 회사의 전체 고객 수
      */
-    Page<CustomerEntity> findAllByStatusAndDeleteYn(CustomerStatus status, String deleteYn, Pageable pageable);
+    long countTotalByCompanyId(Long companyId);
+
+    /**
+     * 회사 ID 및 고객 유형별 고객 수를 조회합니다.
+     *
+     * @param type 고객 유형 ("INDIVIDUAL" 또는 "CORPORATE")
+     * @param companyId 회사의 ID
+     * @return 해당 회사 및 유형의 고객 수
+     */
+    long countByTypeAndCompanyId(CustomerType type, Long companyId);
 }

--- a/admin/src/main/java/kernel360/ckt/admin/application/port/RentalRepository.java
+++ b/admin/src/main/java/kernel360/ckt/admin/application/port/RentalRepository.java
@@ -110,4 +110,13 @@ public interface RentalRepository {
      * @return 조건에 맞는 대여 건수
      */
     long countByCustomerIdAndStatus(Long customerId, RentalStatus status);
+
+    /**
+     * 특정 회사의 현재 대여 중(RENTED 상태)인 고객 수를 조회합니다.
+     * 동일 고객이 여러 대여건을 가지고 있어도 1명으로 계산합니다.
+     *
+     * @param companyId 회사 ID
+     * @return 해당 회사의 대여 중인 고객 수
+     */
+    long countRentedCustomersByCompanyId(Long companyId);
 }

--- a/admin/src/main/java/kernel360/ckt/admin/application/service/CustomerService.java
+++ b/admin/src/main/java/kernel360/ckt/admin/application/service/CustomerService.java
@@ -51,6 +51,12 @@ public class CustomerService {
         CustomerEntity customer = customerRepository.findById(id)
             .orElseThrow(() -> new CustomException(CustomerErrorCode.CUSTOMER_NOT_FOUND));
 
+        customerRepository.findByLicenseNumber(request.licenseNumber())
+            .filter(existing -> !existing.getId().equals(id))
+            .ifPresent(existing -> {
+                throw new CustomException(CustomerErrorCode.DUPLICATE_LICENSE_NUMBER);
+            });
+
         try {
             customer.updateBasicInfo(
                 request.customerType(),

--- a/admin/src/main/java/kernel360/ckt/admin/application/service/CustomerService.java
+++ b/admin/src/main/java/kernel360/ckt/admin/application/service/CustomerService.java
@@ -93,15 +93,15 @@ public class CustomerService {
         log.info("고객 삭제 완료: id={}", id);
     }
 
-    public Page<CustomerEntity> searchCustomers(CustomerStatus status, String keyword, Pageable pageable) {
-        return customerRepository.findAll(status, keyword, pageable);
+    public Page<CustomerEntity> searchCustomers(Long companyId, CustomerStatus status, String keyword, Pageable pageable) {
+        return customerRepository.findAll(companyId, status, keyword, pageable);
     }
 
-    public CustomerSummaryResponse getCustomerSummary() {
-        long total = customerRepository.countTotal();
-        long individual = customerRepository.countByType(CustomerType.INDIVIDUAL);
-        long corporate = customerRepository.countByType(CustomerType.CORPORATE);
-        long renting = rentalRepository.countRentedCustomers();
+    public CustomerSummaryResponse getCustomerSummary(Long companyId) {
+        long total = customerRepository.countTotalByCompanyId(companyId);
+        long individual = customerRepository.countByTypeAndCompanyId(CustomerType.INDIVIDUAL, companyId);
+        long corporate = customerRepository.countByTypeAndCompanyId(CustomerType.CORPORATE, companyId);
+        long renting = rentalRepository.countRentedCustomersByCompanyId(companyId);
 
         return CustomerSummaryResponse.of(total, individual, corporate, renting);
     }

--- a/admin/src/main/java/kernel360/ckt/admin/application/service/CustomerService.java
+++ b/admin/src/main/java/kernel360/ckt/admin/application/service/CustomerService.java
@@ -98,9 +98,9 @@ public class CustomerService {
     }
 
     public CustomerSummaryResponse getCustomerSummary(Long companyId) {
-        long total = customerRepository.countTotalByCompanyId(companyId);
-        long individual = customerRepository.countByTypeAndCompanyId(CustomerType.INDIVIDUAL, companyId);
-        long corporate = customerRepository.countByTypeAndCompanyId(CustomerType.CORPORATE, companyId);
+        long total = customerRepository.countTotalByCompanyIdAndDeleteYn(companyId, "N");
+        long individual = customerRepository.countByTypeAndCompanyIdAndDeleteYn(CustomerType.INDIVIDUAL, companyId, "N");
+        long corporate = customerRepository.countByTypeAndCompanyIdAndDeleteYn(CustomerType.CORPORATE, companyId, "N");
         long renting = rentalRepository.countRentedCustomersByCompanyId(companyId);
 
         return CustomerSummaryResponse.of(total, individual, corporate, renting);

--- a/admin/src/main/java/kernel360/ckt/admin/application/service/CustomerService.java
+++ b/admin/src/main/java/kernel360/ckt/admin/application/service/CustomerService.java
@@ -93,8 +93,8 @@ public class CustomerService {
         log.info("고객 삭제 완료: id={}", id);
     }
 
-    public Page<CustomerEntity> searchCustomers(Long companyId, CustomerStatus status, String keyword, Pageable pageable) {
-        return customerRepository.findAll(companyId, status, keyword, pageable);
+    public Page<CustomerEntity> searchCustomers(Long companyId, CustomerType type, CustomerStatus status, String keyword, Pageable pageable) {
+        return customerRepository.findAll(companyId, type, status, keyword, pageable);
     }
 
     public CustomerSummaryResponse getCustomerSummary(Long companyId) {

--- a/admin/src/main/java/kernel360/ckt/admin/application/service/command/CreateCustomerCommand.java
+++ b/admin/src/main/java/kernel360/ckt/admin/application/service/command/CreateCustomerCommand.java
@@ -10,6 +10,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class CreateCustomerCommand {
 
+    private final Long companyId;
     private final CustomerType customerType;
     private final String email;
     private final String customerName;
@@ -29,10 +30,11 @@ public class CreateCustomerCommand {
             this.phoneNumber,
             this.licenseNumber,
             this.zipCode,
-            this.status,
             this.address,
             this.detailedAddress,
-            this.birthday
+            this.birthday,
+            this.status,
+            this.companyId
         );
     }
 }

--- a/admin/src/main/java/kernel360/ckt/admin/infra/CustomerRepositoryAdapter.java
+++ b/admin/src/main/java/kernel360/ckt/admin/infra/CustomerRepositoryAdapter.java
@@ -24,8 +24,8 @@ public class CustomerRepositoryAdapter implements CustomerRepository {
     }
 
     @Override
-    public Page<CustomerEntity> findAll(Long companyId, CustomerStatus status, String keyword, Pageable pageable) {
-        return customerJpaRepository.findAll(companyId, status, keyword, pageable);
+    public Page<CustomerEntity> findAll(Long companyId, CustomerType type, CustomerStatus status, String keyword, Pageable pageable) {
+        return customerJpaRepository.findAll(companyId, type, status, keyword, pageable);
     }
 
     @Override

--- a/admin/src/main/java/kernel360/ckt/admin/infra/CustomerRepositoryAdapter.java
+++ b/admin/src/main/java/kernel360/ckt/admin/infra/CustomerRepositoryAdapter.java
@@ -49,13 +49,12 @@ public class CustomerRepositoryAdapter implements CustomerRepository {
     }
 
     @Override
-    public long countTotalByCompanyId(Long companyId) {
-        return customerJpaRepository.countByCompanyId(companyId);
+    public long countTotalByCompanyIdAndDeleteYn(Long companyId, String deleteYn) {
+        return customerJpaRepository.countByCompanyIdAndDeleteYn(companyId, deleteYn);
     }
 
     @Override
-    public long countByTypeAndCompanyId(CustomerType type, Long companyId) {
-        return customerJpaRepository.countByCustomerTypeAndCompanyId(type, companyId);
+    public long countByTypeAndCompanyIdAndDeleteYn(CustomerType type, Long companyId, String deleteYn) {
+        return customerJpaRepository.countByCustomerTypeAndCompanyIdAndDeleteYn(type, companyId, deleteYn);
     }
-
 }

--- a/admin/src/main/java/kernel360/ckt/admin/infra/CustomerRepositoryAdapter.java
+++ b/admin/src/main/java/kernel360/ckt/admin/infra/CustomerRepositoryAdapter.java
@@ -24,8 +24,8 @@ public class CustomerRepositoryAdapter implements CustomerRepository {
     }
 
     @Override
-    public Page<CustomerEntity> findAll(CustomerStatus status, String keyword, Pageable pageable) {
-        return customerJpaRepository.findAll(status, keyword, pageable);
+    public Page<CustomerEntity> findAll(Long companyId, CustomerStatus status, String keyword, Pageable pageable) {
+        return customerJpaRepository.findAll(companyId, status, keyword, pageable);
     }
 
     @Override
@@ -39,16 +39,6 @@ public class CustomerRepositoryAdapter implements CustomerRepository {
     }
 
     @Override
-    public long countTotal() {
-        return customerJpaRepository.count();
-    }
-
-    @Override
-    public long countByType(CustomerType type) {
-        return customerJpaRepository.countByCustomerType(type);
-    }
-
-    @Override
     public List<CustomerEntity> search(Long companyId, String customerNameKeyword, String phoneNumberKeyword) {
         return customerJpaRepository.findByDeleteYnAndCompanyIdAndCustomerNameStartingWithOrPhoneNumberStartingWith("N", companyId, customerNameKeyword, phoneNumberKeyword);
     }
@@ -59,8 +49,13 @@ public class CustomerRepositoryAdapter implements CustomerRepository {
     }
 
     @Override
-    public Page<CustomerEntity> findAllByStatusAndDeleteYn(CustomerStatus status, String deleteYn, Pageable pageable) {
-        return customerJpaRepository.findAllByStatusAndDeleteYn(status, deleteYn, pageable);
+    public long countTotalByCompanyId(Long companyId) {
+        return customerJpaRepository.countByCompanyId(companyId);
+    }
+
+    @Override
+    public long countByTypeAndCompanyId(CustomerType type, Long companyId) {
+        return customerJpaRepository.countByCustomerTypeAndCompanyId(type, companyId);
     }
 
 }

--- a/admin/src/main/java/kernel360/ckt/admin/infra/RentalRepositoryAdapter.java
+++ b/admin/src/main/java/kernel360/ckt/admin/infra/RentalRepositoryAdapter.java
@@ -63,4 +63,9 @@ public class RentalRepositoryAdapter implements RentalRepository {
     public long countByCustomerIdAndStatus(Long customerId, RentalStatus status) {
         return rentalJpaRepository.countByCustomerIdAndStatus(customerId, status);
     }
+
+    @Override
+    public long countRentedCustomersByCompanyId(Long companyId) {
+        return rentalJpaRepository.countRentedCustomersByCompanyId(companyId);
+    }
 }

--- a/admin/src/main/java/kernel360/ckt/admin/infra/jpa/CustomerJpaRepository.java
+++ b/admin/src/main/java/kernel360/ckt/admin/infra/jpa/CustomerJpaRepository.java
@@ -17,6 +17,7 @@ public interface CustomerJpaRepository extends JpaRepository<CustomerEntity, Lon
     SELECT c FROM CustomerEntity c
     WHERE c.deleteYn = 'N'
       AND c.companyId = :companyId
+      AND (:type IS NULL OR c.customerType = :type)
       AND (:status IS NULL OR c.status = :status)
       AND (
         :keyword IS NULL
@@ -26,6 +27,7 @@ public interface CustomerJpaRepository extends JpaRepository<CustomerEntity, Lon
     """)
     Page<CustomerEntity> findAll(
         @Param("companyId") Long companyId,
+        @Param("type") CustomerType type,
         @Param("status") CustomerStatus status,
         @Param("keyword") String keyword,
         Pageable pageable

--- a/admin/src/main/java/kernel360/ckt/admin/infra/jpa/CustomerJpaRepository.java
+++ b/admin/src/main/java/kernel360/ckt/admin/infra/jpa/CustomerJpaRepository.java
@@ -37,7 +37,7 @@ public interface CustomerJpaRepository extends JpaRepository<CustomerEntity, Lon
 
     Optional<CustomerEntity> findByIdAndDeleteYn(Long id, String deleteYn);
 
-    long countByCompanyId(Long companyId);
+    long countByCompanyIdAndDeleteYn(Long companyId, String deleteYn);
 
-    long countByCustomerTypeAndCompanyId(CustomerType type, Long companyId);
+    long countByCustomerTypeAndCompanyIdAndDeleteYn(CustomerType type, Long companyId, String deleteYn);
 }

--- a/admin/src/main/java/kernel360/ckt/admin/infra/jpa/CustomerJpaRepository.java
+++ b/admin/src/main/java/kernel360/ckt/admin/infra/jpa/CustomerJpaRepository.java
@@ -16,6 +16,7 @@ public interface CustomerJpaRepository extends JpaRepository<CustomerEntity, Lon
     @Query("""
     SELECT c FROM CustomerEntity c
     WHERE c.deleteYn = 'N'
+      AND c.companyId = :companyId
       AND (:status IS NULL OR c.status = :status)
       AND (
         :keyword IS NULL
@@ -24,6 +25,7 @@ public interface CustomerJpaRepository extends JpaRepository<CustomerEntity, Lon
       )
     """)
     Page<CustomerEntity> findAll(
+        @Param("companyId") Long companyId,
         @Param("status") CustomerStatus status,
         @Param("keyword") String keyword,
         Pageable pageable
@@ -31,16 +33,11 @@ public interface CustomerJpaRepository extends JpaRepository<CustomerEntity, Lon
 
     Optional<CustomerEntity> findByLicenseNumber(String licenseNumber);
 
-    // 전체 고객 수
-    long count();
-
-    // 고객 유형별 (INDIVIDUAL / CORPORATE) 수
-    @Query("SELECT COUNT(c) FROM CustomerEntity c WHERE c.customerType = :type")
-    long countByCustomerType(@Param("type") CustomerType type);
-
     List<CustomerEntity> findByDeleteYnAndCompanyIdAndCustomerNameStartingWithOrPhoneNumberStartingWith(String deleteYn, Long companyId, String customerNameKeyword, String phoneNumberKeyword);
 
     Optional<CustomerEntity> findByIdAndDeleteYn(Long id, String deleteYn);
 
-    Page<CustomerEntity> findAllByStatusAndDeleteYn(CustomerStatus status, String deleteYn, Pageable pageable);
+    long countByCompanyId(Long companyId);
+
+    long countByCustomerTypeAndCompanyId(CustomerType type, Long companyId);
 }

--- a/admin/src/main/java/kernel360/ckt/admin/infra/jpa/RentalJpaRepository.java
+++ b/admin/src/main/java/kernel360/ckt/admin/infra/jpa/RentalJpaRepository.java
@@ -82,4 +82,12 @@ public interface RentalJpaRepository extends JpaRepository<RentalEntity, Long> {
     long countByCustomerId(Long customerId);
 
     long countByCustomerIdAndStatus(Long customerId, RentalStatus status);
+
+    @Query("""
+    SELECT COUNT(DISTINCT r.customer.id)
+    FROM RentalEntity r
+    WHERE r.customer.companyId = :companyId
+      AND r.status = 'RENTED'
+""")
+    long countRentedCustomersByCompanyId(@Param("companyId") Long companyId);
 }

--- a/admin/src/main/java/kernel360/ckt/admin/ui/CustomerController.java
+++ b/admin/src/main/java/kernel360/ckt/admin/ui/CustomerController.java
@@ -11,6 +11,7 @@ import kernel360.ckt.admin.ui.dto.response.*;
 import kernel360.ckt.core.common.response.CommonResponse;
 import kernel360.ckt.core.domain.entity.CustomerEntity;
 import kernel360.ckt.core.domain.enums.CustomerStatus;
+import kernel360.ckt.core.domain.enums.CustomerType;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -34,10 +35,11 @@ public class CustomerController {
     public CommonResponse<CustomerListResponse> getAllCustomers(
         @RequestHeader(X_USER_ID_HEADER) Long companyId,
         @RequestParam(required = false) CustomerStatus status,
+        @RequestParam(required = false) CustomerType type,
         @RequestParam(required = false) String keyword,
         @PageableDefault(size = 10) Pageable pageable
     ) {
-        Page<CustomerEntity> customerPage = customerService.searchCustomers(companyId, status, keyword, pageable);
+        Page<CustomerEntity> customerPage = customerService.searchCustomers(companyId, type, status, keyword, pageable);
         return CommonResponse.success(CustomerListResponse.from(customerPage));
     }
 

--- a/admin/src/main/java/kernel360/ckt/admin/ui/CustomerController.java
+++ b/admin/src/main/java/kernel360/ckt/admin/ui/CustomerController.java
@@ -32,11 +32,12 @@ public class CustomerController {
 
     @GetMapping
     public CommonResponse<CustomerListResponse> getAllCustomers(
+        @RequestHeader(X_USER_ID_HEADER) Long companyId,
         @RequestParam(required = false) CustomerStatus status,
         @RequestParam(required = false) String keyword,
         @PageableDefault(size = 10) Pageable pageable
     ) {
-        Page<CustomerEntity> customerPage = customerService.searchCustomers(status, keyword, pageable);
+        Page<CustomerEntity> customerPage = customerService.searchCustomers(companyId, status, keyword, pageable);
         return CommonResponse.success(CustomerListResponse.from(customerPage));
     }
 
@@ -66,8 +67,10 @@ public class CustomerController {
     }
 
     @GetMapping("/summary")
-    public CommonResponse<CustomerSummaryResponse> getCustomerSummary() {
-        return CommonResponse.success(customerService.getCustomerSummary());
+    public CommonResponse<CustomerSummaryResponse> getCustomerSummary(
+        @RequestHeader(X_USER_ID_HEADER) Long companyId
+    ) {
+        return CommonResponse.success(customerService.getCustomerSummary(companyId));
     }
 
     @GetMapping("/search")

--- a/admin/src/main/java/kernel360/ckt/admin/ui/CustomerController.java
+++ b/admin/src/main/java/kernel360/ckt/admin/ui/CustomerController.java
@@ -1,5 +1,6 @@
 package kernel360.ckt.admin.ui;
 
+import jakarta.validation.Valid;
 import kernel360.ckt.admin.application.service.CustomerRentalQueryService;
 import kernel360.ckt.admin.application.service.CustomerService;
 import kernel360.ckt.admin.application.service.command.CreateCustomerCommand;
@@ -46,17 +47,14 @@ public class CustomerController {
     }
 
     @PostMapping
-    public CommonResponse<CustomerResponse> create(@RequestBody CustomerCreateRequest request) {
-        CreateCustomerCommand command = request.toCommand();
+    public CommonResponse<CustomerResponse> create(@RequestHeader(X_USER_ID_HEADER) Long companyId, @Valid @RequestBody CustomerCreateRequest request) {
+        CreateCustomerCommand command = request.toCommand(companyId);
         CustomerEntity customerEntity = customerService.create(command);
         return CommonResponse.success(CustomerResponse.from(customerEntity));
     }
 
     @PutMapping("/{id}")
-    public CommonResponse<CustomerResponse> update(
-        @PathVariable Long id,
-        @RequestBody CustomerUpdateRequest request
-    ) {
+    public CommonResponse<CustomerResponse> update(@PathVariable Long id, @Valid @RequestBody CustomerUpdateRequest request) {
         CustomerEntity customerEntity = customerService.update(id, request);
         return CommonResponse.success(CustomerResponse.from(customerEntity));
     }

--- a/admin/src/main/java/kernel360/ckt/admin/ui/dto/request/CustomerCreateRequest.java
+++ b/admin/src/main/java/kernel360/ckt/admin/ui/dto/request/CustomerCreateRequest.java
@@ -1,23 +1,37 @@
 package kernel360.ckt.admin.ui.dto.request;
 
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
 import kernel360.ckt.admin.application.service.command.CreateCustomerCommand;
 import kernel360.ckt.core.domain.enums.CustomerStatus;
 import kernel360.ckt.core.domain.enums.CustomerType;
 
 public record CustomerCreateRequest(
+    Long companyId,
+
     CustomerType customerType,
+
+    @NotBlank(message = "이메일은 필수 입력 항목입니다.")
+    @Email(message = "이메일 형식이 올바르지 않습니다.")
     String email,
+
+    @NotBlank(message = "이름은 필수 입력 항목입니다.")
     String customerName,
+
     String phoneNumber,
+
+    @NotBlank(message = "운전면허번호는 필수 입력 항목입니다.")
     String licenseNumber,
+
     String zipCode,
     CustomerStatus status,
     String address,
     String detailedAddress,
     String birthday
 ) {
-    public CreateCustomerCommand toCommand() {
+    public CreateCustomerCommand toCommand(Long companyId) {
         return new CreateCustomerCommand(
+            companyId,
             customerType,
             email,
             customerName,

--- a/core/src/main/java/kernel360/ckt/core/domain/entity/CustomerEntity.java
+++ b/core/src/main/java/kernel360/ckt/core/domain/entity/CustomerEntity.java
@@ -19,17 +19,18 @@ public class CustomerEntity extends BaseTimeEntity {
     @Column(nullable = false)
     private CustomerType customerType;
 
-    @Column(nullable = false, unique = true)
+    @Column(nullable = false)
     private String email;
+
+    @Column
+    private String phoneNumber;
 
     @Column(nullable = false)
     private String customerName;
 
     @Column(nullable = false, unique = true)
-    private String phoneNumber;
-
-    @Column(nullable = false, unique = true)
     private String licenseNumber;
+
     private String zipCode;
     private String address;
     private String detailedAddress;
@@ -39,9 +40,8 @@ public class CustomerEntity extends BaseTimeEntity {
     @Column(nullable = false)
     private CustomerStatus status;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "company_id")
-    private CompanyEntity company;
+    @Column(name = "company_id", nullable = false)
+    private Long companyId;
 
     @Column(name = "delete_yn", nullable = false, length = 1, columnDefinition = "CHAR(1)")
     private String deleteYn = "N";
@@ -55,7 +55,8 @@ public class CustomerEntity extends BaseTimeEntity {
                           String address,
                           String detailedAddress,
                           String birthday,
-                          CustomerStatus status) {
+                          CustomerStatus status,
+                          Long companyId) {
         this.customerType = customerType;
         this.email = email;
         this.customerName = customerName;
@@ -66,6 +67,7 @@ public class CustomerEntity extends BaseTimeEntity {
         this.detailedAddress = detailedAddress;
         this.birthday = birthday;
         this.status = status;
+        this.companyId = companyId;
     }
 
     public static CustomerEntity create(
@@ -75,10 +77,11 @@ public class CustomerEntity extends BaseTimeEntity {
         String phoneNumber,
         String licenseNumber,
         String zipCode,
-        CustomerStatus status,
         String address,
         String detailedAddress,
-        String birthday
+        String birthday,
+        CustomerStatus status,
+        Long companyId
     ) {
         return new CustomerEntity(
             customerType,
@@ -90,7 +93,8 @@ public class CustomerEntity extends BaseTimeEntity {
             address,
             detailedAddress,
             birthday,
-            status
+            status,
+            companyId
         );
     }
 
@@ -119,5 +123,4 @@ public class CustomerEntity extends BaseTimeEntity {
     public void markAsDeleted() {
         this.deleteYn = "Y";
     }
-
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
<!-- ex) #이슈번호[, #이슈번호] -->

> #110 

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 설명해 주세요. (이미지 첨부 가능) -->

 - **CustomerEntity**  
   - `@ManyToOne` 관계 제거 후 `companyId` 컬럼으로 변경  
   - `email`, `phoneNumber` nullable/unique 제약 수정, `licenseNumber`만 unique 유지  

 - **CreateCustomerCommand**  
   - `companyId` 필드 추가 및 생성자·toEntity 호출 시 반영  

 - **CustomerService**  
   - `update()` 메서드에서 면허번호 중복 검증 로직 추가 (`existsByLicenseNumberAndIdNot` 활용)  

 - **CustomerController**     - `@RequestHeader("X-User-Id") Long companyId` 주입  
   - `create`/`update` API에서 `companyId`를 DTO → Command에 전달  

 - **CustomerCreateRequest**  
   - `companyId` 필드 추가, `toCommand(Long)` 시그니처 업데이트  

 - **X-USER-ID 헤더 기반 고객 필터링 및 통계 적용**  
   - 고객 요약 API(`/summary`) 및 목록 API(`/customers`)에 `companyId` 기반 필터링 적용  
   - `countTotalByCompanyId`, `countByTypeAndCompanyId` → soft delete 대응 (`deleteYn = 'N'`) 처리

 - **고객 유형(CustomerType) 필터링 기능 추가**  
   - 목록 API에서 `?type=INDIVIDUAL|CORPORATE` 파라미터 지원  
   - 프론트의 개인/법인 탭 클릭 시, 백엔드에서 직접 필터링 가능  

 - **불필요한 size=1000 파라미터 제거**  
   - 고객 목록 API 호출 시 기본 `@PageableDefault(size = 10)` 값 따르도록 변경하여 성능 최적화