### PR TITLE
fix: 애뮬레이터 시동 ON 호출 시 Null pointer 에러 발생하는 현상 수정

### DIFF
--- a/collector/src/main/java/kernel360/ckt/collector/ui/VehicleCollectorController.java
+++ b/collector/src/main/java/kernel360/ckt/collector/ui/VehicleCollectorController.java
@@ -66,7 +66,7 @@ public class VehicleCollectorController {
      */
     @PostMapping("/cycle")
     CommonResponse<VehicleCollectorResponse> saveVehicleCycle(@Valid @RequestBody VehicleCollectorCycleRequest request) {
-        log.info("차량 주기적 위치 정보 저장 요청 - {}", request);
+        log.info("차량 주기적 위치 정보 저장 요청 - {}", request.mdn());
         final VehicleCollectorCycleCommand cycleCommand = request.toCommand();
         return CommonResponse.success(vehicleCollectorService.saveVehicleCycle(cycleCommand));
     }

--- a/core/src/main/java/kernel360/ckt/core/domain/entity/VehicleEntity.java
+++ b/core/src/main/java/kernel360/ckt/core/domain/entity/VehicleEntity.java
@@ -103,7 +103,9 @@ public class VehicleEntity extends BaseTimeEntity {
     public void updateLocation(Double lat, Double lon, Long odometer) {
         this.lat = lat;
         this.lon = lon;
-        this.odometer = this.odometer + odometer;
+
+        final long currentOdometer = (this.odometer != null) ? this.odometer : 0L;
+        this.odometer = currentOdometer + odometer;
     }
 
     public void delete() {


### PR DESCRIPTION
## #️⃣ 연관된 이슈
<!-- ex) #이슈번호[, #이슈번호] -->

- #107 


## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 설명해 주세요. (이미지 첨부 가능) -->

- 애뮬레이터 시동 ON시 Vehicle 의 update 가정에서 Null Pointer 에러 발생
   - 기존 default 가 0으로 설정되어 있으나, Data를 직접 밀어넣는 과정에서 null로 들어가는 이슈
   - 만약을 위해 Null Pinter 에러를 해결하기 위한 로직을 추가
- 애뮬레이터 주기 정보 전송시 cloud watch에서 로그가 과하게 찍히는 현상 수정

## 👀 리뷰어 가이드라인
<!-- 리뷰어가 중점적으로 확인해야 할 사항을 작성해 주세요. -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

- 데이터가 없는 경우에 Null Pointer 에러가 발생해서 방어 로직 추가해두었습니다.
