### PR TITLE
feat: 시동은 켜졌지만 렌탈 정보가 없는 차량 도난 분류 기능 추가(실시간 관제)

### DIFF
--- a/admin/src/main/java/kernel360/ckt/admin/application/port/VehicleRepository.java
+++ b/admin/src/main/java/kernel360/ckt/admin/application/port/VehicleRepository.java
@@ -60,4 +60,8 @@ public interface VehicleRepository {
      * @param returnAt 반납 시간
      */
     List<VehicleEntity> searchAvailableVehiclesByKeyword(Long companyId, String keyword, LocalDateTime pickupAt, LocalDateTime returnAt);
+
+    long countStolenVehicles(List<Long> runningVehicleIds);
+
+    List<Long> findStolenVehicleIds(List<Long> vehicleIds);
 }

--- a/admin/src/main/java/kernel360/ckt/admin/infra/VehicleRepositoryAdapter.java
+++ b/admin/src/main/java/kernel360/ckt/admin/infra/VehicleRepositoryAdapter.java
@@ -47,4 +47,14 @@ public class VehicleRepositoryAdapter implements VehicleRepository {
     public List<VehicleEntity> searchAvailableVehiclesByKeyword(Long companyId, String keyword, LocalDateTime pickupAt, LocalDateTime returnAt) {
         return vehicleJpaRepository.searchAvailableVehiclesByKeyword(companyId, keyword, pickupAt, returnAt);
     }
+
+    @Override
+    public long countStolenVehicles(List<Long> runningVehicleIds) {
+        return vehicleJpaRepository.countStolenVehicles(runningVehicleIds);
+    }
+
+    @Override
+    public List<Long> findStolenVehicleIds(List<Long> vehicleIds) {
+        return vehicleJpaRepository.findStolenVehicleIds(vehicleIds);
+    }
 }

--- a/admin/src/main/java/kernel360/ckt/admin/infra/jpa/VehicleJpaRepository.java
+++ b/admin/src/main/java/kernel360/ckt/admin/infra/jpa/VehicleJpaRepository.java
@@ -47,4 +47,24 @@ public interface VehicleJpaRepository extends JpaRepository<VehicleEntity, Long>
         @Param("pickupAt") LocalDateTime pickupAt,
         @Param("returnAt") LocalDateTime returnAt
     );
+
+    @Query("""
+    SELECT COUNT(v) FROM VehicleEntity v
+    WHERE v.id IN :vehicleIds
+    AND NOT EXISTS (
+        SELECT 1 FROM RentalEntity r
+        WHERE r.vehicle = v
+    )
+""")
+    long countStolenVehicles(@Param("vehicleIds") List<Long> vehicleIds);
+
+    @Query("""
+    SELECT v.id FROM VehicleEntity v
+    WHERE v.id IN :vehicleIds
+    AND NOT EXISTS (
+        SELECT 1 FROM RentalEntity r
+        WHERE r.vehicle = v
+    )
+""")
+    List<Long> findStolenVehicleIds(@Param("vehicleIds") List<Long> vehicleIds);
 }

--- a/admin/src/main/java/kernel360/ckt/admin/ui/dto/response/ControlTowerSummaryResponse.java
+++ b/admin/src/main/java/kernel360/ckt/admin/ui/dto/response/ControlTowerSummaryResponse.java
@@ -3,9 +3,10 @@ package kernel360.ckt.admin.ui.dto.response;
 public record ControlTowerSummaryResponse(
     int total,
     int running,
+    int stolen,
     int stopped
 ) {
-    public static ControlTowerSummaryResponse of(int total, int running, int stopped) {
-        return new ControlTowerSummaryResponse(total, running, stopped);
+    public static ControlTowerSummaryResponse of(int total, int running, int stolen, int stopped) {
+        return new ControlTowerSummaryResponse(total, running, stolen, stopped);
     }
 }

--- a/admin/src/main/java/kernel360/ckt/admin/ui/dto/response/RunningVehicleResponse.java
+++ b/admin/src/main/java/kernel360/ckt/admin/ui/dto/response/RunningVehicleResponse.java
@@ -10,7 +10,8 @@ public record RunningVehicleResponse(
     String customerName,
     String lat,
     String lon,
-    String spd
+    String spd,
+    boolean stolen
 ) {
     public static RunningVehicleResponse from(RunningVehicleProjection p) {
         return new RunningVehicleResponse(
@@ -21,7 +22,21 @@ public record RunningVehicleResponse(
             p.getCustomerName(),
             p.getLat(),
             p.getLon(),
-            p.getSpd()
+            p.getSpd(),
+            false
+        );
+    }
+    public static RunningVehicleResponse from(RunningVehicleProjection p, boolean stolen) {
+        return new RunningVehicleResponse(
+            p.getVehicleId(),
+            p.getRegistrationNumber(),
+            p.getManufacturer(),
+            p.getModelName(),
+            p.getCustomerName(),
+            p.getLat(),
+            p.getLon(),
+            p.getSpd(),
+            stolen
         );
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
<!-- ex) #이슈번호[, #이슈번호] -->

> #116 



## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 설명해 주세요. (이미지 첨부 가능) -->

 - `VehicleControlTowerService`  
   - 운행 중 차량 ID 목록 기반으로 도난 차량 ID를 조회하여 각 차량에 `stolen` 여부 설정  
   - 전체 통계 집계 시 `stolen` 차량을 별도로 분류하여 `stopped` 계산 정확도 개선

 - `VehicleRepository`, `VehicleRepositoryAdapter`  
   - `findStolenVehicleIds(List<Long>)` 메서드 추가  
   - 렌탈 정보가 없는 운행 차량을 도난 차량으로 간주하여 조회

 - `VehicleJpaRepository`  
   - JPQL 기반 도난 차량 ID 조회 쿼리 추가 (`NOT EXISTS Rental`)

 - `ControlTowerSummaryResponse`  
   - `stolen` 필드 추가  
   - `of(...)` 정적 팩토리 메서드 확장

 - `RunningVehicleResponse`  
   - `stolen` 필드 추가  
   - `.from(projection, isStolen)` 오버로드 메서드 추가

## 👀 리뷰어 가이드라인
<!-- 리뷰어가 중점적으로 확인해야 할 사항을 작성해 주세요. -->

> - `stolen` 판단 기준이 비즈니스 로직에 적절히 반영되었는지 확인 부탁드립니다  
> - `stopped` 계산 로직에서 `stolen`을 제외하여 합계가 정확히 맞는지 체크해주세요  
> - 응답 DTO에 `stolen` 필드가 빠짐없이 들어가는지 확인해주세요