### PR TITLE
fix: 운행일지 시작 계기판이 0으로 고정되는 버그 수정

### DIFF
--- a/collector/src/main/java/kernel360/ckt/collector/application/service/VehicleCollectorService.java
+++ b/collector/src/main/java/kernel360/ckt/collector/application/service/VehicleCollectorService.java
@@ -54,8 +54,8 @@ public class VehicleCollectorService {
             throw new CustomException(VehicleEventErrorCode.ALREADY_RUNNING);
         }
 
-        // 차량 위치 및 총 주행거리 업데이트
-        vehicle.updateLocation(command.lat(), command.lon(), command.totalDistance());
+        // 차량 위치 업데이트
+        vehicle.updateLocation(command.lat(), command.lon());
         final VehicleEntity updatedVehicle = vehicleRepository.save(vehicle);
         log.info("차량 위치 및 총 주행거리 업데이트 - 위치 : {}, {}, 총 주행거리 : {}", updatedVehicle.getLat(), updatedVehicle.getLon(), updatedVehicle.getOdometer());
 
@@ -81,7 +81,7 @@ public class VehicleCollectorService {
         }
 
         // 새로운 경로 시작
-        final RouteEntity route = routeRepository.save(command.toRouteEntity(drivingLog));
+        final RouteEntity route = routeRepository.save(command.toRouteEntity(drivingLog, updatedVehicle));
         log.info("새로운 경로 생성 - 경로 ID : {}", route.getId());
 
         // 차량 이벤트 저장
@@ -119,8 +119,9 @@ public class VehicleCollectorService {
         final RouteEntity route = findActiveRoute(drivingLog);
         log.info("진행 중인 경로 - 경로 ID : {}", route.getId());
 
-        // 차량 위치 및 총 주행거리 업데이트
-        vehicle.updateLocation(command.lat(), command.lon(), command.totalDistance());
+        // 차량 위치 및 업데이트
+        vehicle.updateLocation(command.lat(), command.lon());
+        vehicle.updateOdometer(command.totalDistance());
         final VehicleEntity updatedVehicle = vehicleRepository.save(vehicle);
         log.info("차량 위치 및 총 주행거리 업데이트 - 위치 : {}, {}, 총 주행거리 : {}", updatedVehicle.getLat(), updatedVehicle.getLon(), updatedVehicle.getOdometer());
 
@@ -182,9 +183,8 @@ public class VehicleCollectorService {
             final CycleInformation cycleInformation = lastElementOptional.get();
             final double lat = Double.parseDouble(cycleInformation.lat()) / GPS_COORDINATE_DIVISOR;
             final double lon = Double.parseDouble(cycleInformation.lon()) / GPS_COORDINATE_DIVISOR;
-            final long totalDistance = Long.parseLong(cycleInformation.sum());
 
-            vehicle.updateLocation(lat, lon, totalDistance);
+            vehicle.updateLocation(lat, lon);
             vehicleRepository.save(vehicle);
         };
 

--- a/collector/src/main/java/kernel360/ckt/collector/application/service/command/VehicleCollectorOnCommand.java
+++ b/collector/src/main/java/kernel360/ckt/collector/application/service/command/VehicleCollectorOnCommand.java
@@ -29,7 +29,9 @@ public record VehicleCollectorOnCommand(
         return DrivingLogEntity.create(rental, vehicle);
     }
 
-    public RouteEntity toRouteEntity(DrivingLogEntity drivingLog) {
-        return RouteEntity.create(drivingLog, this.lat, this.lon, this.totalDistance, this.onTime);
+    public RouteEntity toRouteEntity(DrivingLogEntity drivingLog, VehicleEntity vehicle) {
+        final Long odometer = vehicle.getOdometer();
+        final long startOdometer = ((odometer != null) ? odometer : 0L) + this.totalDistance;
+        return RouteEntity.create(drivingLog, this.lat, this.lon, startOdometer, this.onTime);
     }
 }

--- a/core/src/main/java/kernel360/ckt/core/domain/entity/RouteEntity.java
+++ b/core/src/main/java/kernel360/ckt/core/domain/entity/RouteEntity.java
@@ -66,12 +66,12 @@ public class RouteEntity {
         return new RouteEntity(drivingLog, RouteStatus.ACTIVE, startLat, startLon, startOdometer, startAt);
     }
 
-    public void completed(double endLat, double endLon, long endOdometer, LocalDateTime endAt) {
+    public void completed(double endLat, double endLon, long totalDistance, LocalDateTime endAt) {
         this.status = RouteStatus.COMPLETED;
         this.endLat = endLat;
         this.endLon = endLon;
-        this.endOdometer = endOdometer;
-        this.totalDistance = endOdometer - this.startOdometer;
+        this.endOdometer = this.startOdometer + totalDistance;
+        this.totalDistance = totalDistance;
         this.endAt = endAt;
     }
 }

--- a/core/src/main/java/kernel360/ckt/core/domain/entity/VehicleEntity.java
+++ b/core/src/main/java/kernel360/ckt/core/domain/entity/VehicleEntity.java
@@ -100,12 +100,14 @@ public class VehicleEntity extends BaseTimeEntity {
         this.memo = memo;
     }
 
-    public void updateLocation(Double lat, Double lon, Long odometer) {
+    public void updateLocation(Double lat, Double lon) {
         this.lat = lat;
         this.lon = lon;
+    }
 
+    public void updateOdometer(Long totalDistance) {
         final long currentOdometer = (this.odometer != null) ? this.odometer : 0L;
-        this.odometer = currentOdometer + odometer;
+        this.odometer = currentOdometer + totalDistance;
     }
 
     public void delete() {


### PR DESCRIPTION
## #️⃣ 연관된 이슈
<!-- ex) #이슈번호[, #이슈번호] -->

- #115 


## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 설명해 주세요. (이미지 첨부 가능) -->

- 운행일지 시작 계기판이 시작할때마다 0으로 고정되는 버그 수정


## 👀 리뷰어 가이드라인
<!-- 리뷰어가 중점적으로 확인해야 할 사항을 작성해 주세요. -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

- 경로 시작 및 종료시에 기존 차량의 odemeter 에서 추가하여 저장하는 방식으로 처리 변경했습니다.
