### PR TITLE
chore: collector MQ 성능 개선을 위한 설정 변경

### DIFF
--- a/collector/src/main/java/kernel360/ckt/collector/config/AsyncConfig.java
+++ b/collector/src/main/java/kernel360/ckt/collector/config/AsyncConfig.java
@@ -1,12 +1,10 @@
 package kernel360.ckt.collector.config;
 
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Profile;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.context.annotation.Bean;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
-@Profile("publisher")
 @Configuration
 @EnableAsync
 public class AsyncConfig {
@@ -15,7 +13,7 @@ public class AsyncConfig {
         ThreadPoolTaskExecutor exec = new ThreadPoolTaskExecutor();
         exec.setCorePoolSize(10);
         exec.setMaxPoolSize(50);
-        exec.setQueueCapacity(200);
+        exec.setQueueCapacity(1000);
         exec.setThreadNamePrefix("collector-");
         exec.initialize();
         return exec;

--- a/collector/src/main/java/kernel360/ckt/collector/config/ConsumerConfig.java
+++ b/collector/src/main/java/kernel360/ckt/collector/config/ConsumerConfig.java
@@ -1,0 +1,22 @@
+package kernel360.ckt.collector.config;
+
+import org.springframework.amqp.rabbit.config.SimpleRabbitListenerContainerFactory;
+import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+import org.springframework.amqp.core.AcknowledgeMode;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class ConsumerConfig {
+    @Bean
+    public SimpleRabbitListenerContainerFactory rabbitListenerContainerFactory(ConnectionFactory connectionFactory) {
+        SimpleRabbitListenerContainerFactory factory = new SimpleRabbitListenerContainerFactory();
+        factory.setConnectionFactory(connectionFactory);
+        factory.setConcurrentConsumers(2);
+        factory.setMaxConcurrentConsumers(8);
+        factory.setPrefetchCount(4);
+        factory.setAcknowledgeMode(AcknowledgeMode.AUTO);
+        factory.setDefaultRequeueRejected(false);
+        return factory;
+    }
+}

--- a/collector/src/main/java/kernel360/ckt/collector/consumer/GpsDataConsumer.java
+++ b/collector/src/main/java/kernel360/ckt/collector/consumer/GpsDataConsumer.java
@@ -7,12 +7,10 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.amqp.rabbit.annotation.RabbitListener;
-import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
 @Slf4j
 @Component
-@Profile("consumer")
 @RequiredArgsConstructor
 public class GpsDataConsumer {
 

--- a/collector/src/main/java/kernel360/ckt/collector/consumer/GpsViewConsumer.java
+++ b/collector/src/main/java/kernel360/ckt/collector/consumer/GpsViewConsumer.java
@@ -6,7 +6,6 @@ import kernel360.ckt.collector.config.SseEmitterManager;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.amqp.rabbit.annotation.RabbitListener;
-import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
@@ -14,14 +13,11 @@ import java.io.IOException;
 
 @Slf4j
 @Component
-@Profile("consumer")
 @RequiredArgsConstructor
 public class GpsViewConsumer {
 
     private final ObjectMapper objectMapper;
     private final SseEmitterManager sseEmitterManager;
-
-    // `addEmitter` static 메서드 제거
 
     // RabbitMQ에서 메시지를 받으면 모든 SSE 클라이언트에게 전송
     @RabbitListener(queues = RabbitConfig.VIEW_QUEUE)

--- a/collector/src/main/java/kernel360/ckt/collector/ui/SseController.java
+++ b/collector/src/main/java/kernel360/ckt/collector/ui/SseController.java
@@ -3,14 +3,12 @@ package kernel360.ckt.collector.ui;
 import kernel360.ckt.collector.config.SseEmitterManager;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.context.annotation.Profile;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 @Slf4j
-@Profile("consumer")
 @RestController
 @RequestMapping("/api/v1/sse")
 @RequiredArgsConstructor

--- a/collector/src/main/java/kernel360/ckt/collector/ui/VehicleCollectorController.java
+++ b/collector/src/main/java/kernel360/ckt/collector/ui/VehicleCollectorController.java
@@ -12,7 +12,6 @@ import kernel360.ckt.core.common.response.CommonResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
-import org.springframework.context.annotation.Profile;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -28,7 +27,6 @@ import org.springframework.web.context.request.async.DeferredResult;
  *
  */
 @Slf4j
-@Profile("publisher")
 @RequiredArgsConstructor
 @RequestMapping(value = "/api/v1/vehicles/collector")
 @RestController

--- a/collector/src/main/resources/application-local.yml
+++ b/collector/src/main/resources/application-local.yml
@@ -3,6 +3,10 @@ spring:
     activate:
       on-profile: local
 
+  datasource:
+    hikari:
+      maximum-pool-size: 20
+
   jpa:
     hibernate:
       ddl-auto: update

--- a/collector/src/main/resources/application-prod.yml
+++ b/collector/src/main/resources/application-prod.yml
@@ -3,6 +3,10 @@ spring:
     activate:
       on-profile: prod
 
+  datasource:
+    hikari:
+      maximum-pool-size: 20
+
   jpa:
     hibernate:
       ddl-auto: none

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,7 +41,7 @@ services:
     ports:
       - "8080:8080"
     environment:
-      SPRING_PROFILES_ACTIVE: ${SPRING_PROFILES_ACTIVE} # docker
+      SPRING_PROFILES_ACTIVE: docker #${SPRING_PROFILES_ACTIVE} # docker
       SPRING_REACTOR_CONTEXT_PROPAGATION: AUTO
       JWT_SECRET: ${JWT_SECRET}
     depends_on:
@@ -70,28 +70,6 @@ services:
       SPRING_RABBITMQ_PASSWORD: ${SPRING_RABBITMQ_PASSWORD}
     ports:
       - "8090:8090"
-    volumes:
-      - ./logs:/logs
-    networks:
-      - ckt_network
-  consumer:
-    build:
-      context: ./collector
-    depends_on:
-      - db
-      - rabbitmq
-    environment:
-      SERVER_PORT: 8091
-      SPRING_PROFILES_ACTIVE: consumer,${SPRING_PROFILES_ACTIVE}
-      SPRING_DATASOURCE_URL: jdbc:mysql://${DB_URL}:3306/${DB_DATABASE}
-      SPRING_DATASOURCE_USERNAME: ${DB_USERNAME}
-      SPRING_DATASOURCE_PASSWORD: ${DB_PASSWORD}
-      SPRING_RABBITMQ_HOST: ${SPRING_RABBITMQ_HOST}
-      SPRING_RABBITMQ_PORT: ${SPRING_RABBITMQ_PORT}
-      SPRING_RABBITMQ_USERNAME: ${SPRING_RABBITMQ_USERNAME}
-      SPRING_RABBITMQ_PASSWORD: ${SPRING_RABBITMQ_PASSWORD}
-    ports:
-      - "8091:8091"
     volumes:
       - ./logs:/logs
     networks:

--- a/gateway/src/main/resources/application-docker.yml
+++ b/gateway/src/main/resources/application-docker.yml
@@ -5,12 +5,7 @@ spring:
         - id: collector
           uri: http://collector:8090
           predicates:
-            - Path=/api/v1/vehicles/collector/**
-
-        - id: consumer
-          uri: http://consumer:8091
-          predicates:
-            - Path=/api/v1/sse/**
+            - Path=/api/v1/vehicles/collector/**, /api/v1/sse/**
 
         - id: admin
           uri: http://admin:8081

--- a/gateway/src/main/resources/application-local.yml
+++ b/gateway/src/main/resources/application-local.yml
@@ -5,12 +5,7 @@ spring:
         - id: collector
           uri: http://localhost:8090
           predicates:
-            - Path=/api/v1/vehicles/collector/**
-
-        - id: consumer
-          uri: http://localhost:8091
-          predicates:
-            - Path=/api/v1/sse/**
+            - Path=/api/v1/vehicles/collector/**, /api/v1/sse/**
 
         - id: admin
           uri: http://localhost:8081

--- a/gateway/src/main/resources/application-prod.yml
+++ b/gateway/src/main/resources/application-prod.yml
@@ -5,12 +5,7 @@ spring:
         - id: collector
           uri: http://collector.ckt:8090
           predicates:
-            - Path=/api/v1/vehicles/collector/**
-
-        - id: consumer
-          uri: http://collector.ckt:8091
-          predicates:
-            - Path=/api/v1/sse/**
+            - Path=/api/v1/vehicles/collector/**, /api/v1/sse/**
 
         - id: admin
           uri: http://admin.ckt:8081


### PR DESCRIPTION
## #️⃣ 연관된 이슈
<!-- ex) #이슈번호[, #이슈번호] -->

- #123 


## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 설명해 주세요. (이미지 첨부 가능) -->

- collector 와 consumer 서버의 @profile 분리 병합
- hikariCP max connection 개수 변경

## 👀 리뷰어 가이드라인
<!-- 리뷰어가 중점적으로 확인해야 할 사항을 작성해 주세요. -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

- async config 의 queue 개수가 적당한지 확인 부탁드립니다.
- hikariCP 의 max connection 개수가 적당한지 확인 부탁드립니다.
  - 현재 RDS의 최대 connection 개수 : 85개
