### PR TITLE
feat: 차량 시동 이벤트 SSE 기능 추가

### DIFF
--- a/collector/src/main/java/kernel360/ckt/collector/application/service/dto/GpsSseDto.java
+++ b/collector/src/main/java/kernel360/ckt/collector/application/service/dto/GpsSseDto.java
@@ -1,0 +1,13 @@
+package kernel360.ckt.collector.application.service.dto;
+
+public record GpsSseDto(
+    Long vehicleId,
+    String registrationNumber,
+    String modelName,
+    String manufacturer,
+    double lat,
+    double lon,
+    int spd,
+    String customerName,
+    Boolean stolen
+) {}

--- a/collector/src/main/java/kernel360/ckt/collector/application/service/dto/GpsSummarySseDto.java
+++ b/collector/src/main/java/kernel360/ckt/collector/application/service/dto/GpsSummarySseDto.java
@@ -1,0 +1,9 @@
+package kernel360.ckt.collector.application.service.dto;
+
+public record GpsSummarySseDto(
+    Long vehicleId,
+    double lat,
+    double lon,
+    int spd,
+    Boolean stolen
+) {}

--- a/collector/src/main/java/kernel360/ckt/collector/config/SseEmitterManager.java
+++ b/collector/src/main/java/kernel360/ckt/collector/config/SseEmitterManager.java
@@ -14,20 +14,19 @@ public class SseEmitterManager {
 
     public void add(SseEmitter emitter) {
         this.sseEmitters.add(emitter);
-        log.info("새로운 SSE 클라이언트 연결됨. 현재 클라이언트 수: {}", this.sseEmitters.size());
+        log.debug("새로운 SSE 클라이언트 연결됨. 현재 클라이언트 수: {}", this.sseEmitters.size());
 
         // 타임아웃, 완료 시 리스트에서 제거
         emitter.onCompletion(() -> {
             this.sseEmitters.remove(emitter);
-            log.info("SSE 연결 완료로 제거됨. 현재 클라이언트 수: {}", this.sseEmitters.size());
+            log.debug("SSE 연결 완료로 제거됨. 현재 클라이언트 수: {}", this.sseEmitters.size());
         });
         emitter.onTimeout(() -> {
             this.sseEmitters.remove(emitter);
-            log.info("SSE 연결 타임아웃으로 제거됨. 현재 클라이언트 수: {}", this.sseEmitters.size());
+            log.debug("SSE 연결 타임아웃으로 제거됨. 현재 클라이언트 수: {}", this.sseEmitters.size());
         });
         emitter.onError(throwable -> {
             this.sseEmitters.remove(emitter);
-            log.error("SSE 연결 오류로 제거됨.", throwable);
         });
     }
 

--- a/collector/src/main/java/kernel360/ckt/collector/consumer/GpsViewConsumer.java
+++ b/collector/src/main/java/kernel360/ckt/collector/consumer/GpsViewConsumer.java
@@ -1,8 +1,11 @@
 package kernel360.ckt.collector.consumer;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import kernel360.ckt.collector.application.service.dto.GpsSummarySseDto;
 import kernel360.ckt.collector.config.RabbitConfig;
 import kernel360.ckt.collector.config.SseEmitterManager;
+import kernel360.ckt.collector.ui.dto.request.VehicleCollectorCycleRequest;
+import kernel360.ckt.core.domain.dto.CycleInformation;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.amqp.rabbit.annotation.RabbitListener;
@@ -17,28 +20,44 @@ import java.io.IOException;
 @Profile("consumer")
 @RequiredArgsConstructor
 public class GpsViewConsumer {
-
-    private final ObjectMapper objectMapper;
     private final SseEmitterManager sseEmitterManager;
+    private final ObjectMapper objectMapper;
+
+    private static final double GPS_COORDINATE_DIVISOR = 1000000.0;
 
     // `addEmitter` static 메서드 제거
 
     // RabbitMQ에서 메시지를 받으면 모든 SSE 클라이언트에게 전송
     @RabbitListener(queues = RabbitConfig.VIEW_QUEUE)
     public void receiveGpsDataAndStreamToSse(String message) {
-
-        // 매니저를 통해 Emitters 리스트에 접근
-        log.info("sse emitters: {} ", sseEmitterManager.getEmitters().size());
-        for (SseEmitter emitter : sseEmitterManager.getEmitters()) {
-            try {
-                // SseEmitter.event()를 사용하여 이벤트 형식으로 데이터 전송
-                emitter.send(SseEmitter.event().name("gps-update").data(message));
-                log.info("SSE 스트리밍 전송 완료");
-            } catch (IOException e) {
-                log.error("SSE 클라이언트 전송 실패, 연결 끊김. Emitter 제거 예정.", e);
+        try {
+            final VehicleCollectorCycleRequest vehicleCollectorCycle = objectMapper.readValue(message, VehicleCollectorCycleRequest.class);
+            if (vehicleCollectorCycle.cList().isEmpty()) {
+                return;
             }
+
+            final CycleInformation lastCycleInfo = vehicleCollectorCycle.cList().get(vehicleCollectorCycle.cList().size() - 1);
+            final double lat = Double.parseDouble(lastCycleInfo.lat()) / GPS_COORDINATE_DIVISOR;
+            final double lon = Double.parseDouble(lastCycleInfo.lon()) / GPS_COORDINATE_DIVISOR;
+            final int speed = Integer.parseInt(lastCycleInfo.spd());
+
+            final GpsSummarySseDto gpsSseDto = new GpsSummarySseDto(
+                vehicleCollectorCycle.mdn(), lat, lon, speed, null
+            );
+
+            // 매니저를 통해 Emitters 리스트에 접근
+            log.info("sse emitters: {} ", sseEmitterManager.getEmitters().size());
+            for (SseEmitter emitter : sseEmitterManager.getEmitters()) {
+                try {
+                    emitter.send(SseEmitter.event().name("gps-update").data(objectMapper.writeValueAsString(gpsSseDto)));
+                    log.info("SSE 스트리밍 전송 완료");
+                } catch (IOException e) {
+                    log.error("SSE GPS Update 전송 실패 > ", e);
+                }
+            }
+        } catch (IOException e) {
+            log.error("RabbitMQ 메시지 역직렬화 또는 SSE JSON 직렬화 실패 > ", e);
         }
     }
-
 
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
<!-- ex) #이슈번호[, #이슈번호] -->

- #128 


## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 설명해 주세요. (이미지 첨부 가능) -->

- 차량의 시동 ON/OFF 이벤트에 대한 SSE 기능 추가
- 차량 주기 정보 SSE 전송 데이터 parsing 작업


## 👀 리뷰어 가이드라인
<!-- 리뷰어가 중점적으로 확인해야 할 사항을 작성해 주세요. -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

- 차량 주기 정보 전송 시 데이터가 너무 크게 전송되고 있는 것 같아서 필요한 값만 전송하도록 변경하였습니다.
- 차량 시동 이벤트에 대한 SSE 기능이 없어 화면상에서 차량의 시동 시작과 끝을 감지할 수 없어 추가하였습니다.
