### PR TITLE
fix: 운행 차량 수 계산 시 도난 차량 제외

### DIFF
--- a/admin/src/main/java/kernel360/ckt/admin/application/service/VehicleControlTowerService.java
+++ b/admin/src/main/java/kernel360/ckt/admin/application/service/VehicleControlTowerService.java
@@ -18,10 +18,8 @@ public class VehicleControlTowerService {
     private final TraceLogQueryRepository traceLogQueryRepository;
 
     public ControlTowerSummaryResponse getControlTowerSummary() {
-        // 전체 차량 수
         long total = vehicleRepository.count();
 
-        // 운행 중 차량 리스트
         List<RunningVehicleProjection> runningProjections = traceLogQueryRepository.findRunningVehicleLocations();
         List<Long> runningVehicleIds = runningProjections.stream()
             .map(RunningVehicleProjection::getVehicleId)
@@ -31,7 +29,7 @@ public class VehicleControlTowerService {
 
         long stolen = vehicleRepository.countStolenVehicles(runningVehicleIds);
 
-        long stopped = total - running - stolen;
+        long stopped = total - running;
 
         return ControlTowerSummaryResponse.of((int) total, (int) running, (int) stolen, (int) stopped);
     }


### PR DESCRIPTION

## #️⃣ 연관된 이슈
<!-- ex) #이슈번호[, #이슈번호] -->

> #127 


## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 설명해 주세요. (이미지 첨부 가능) -->

> 컨트롤타워 요약 수치에서 미운행 차량 수를 계산할 때  
> `total - running - stolen`으로 계산되던 기존 로직을  
> `total - running`으로 수정

